### PR TITLE
RFC: Key-Value Separation for Mini-LSM

### DIFF
--- a/rfcs/001-key-value-separation.md
+++ b/rfcs/001-key-value-separation.md
@@ -1,0 +1,773 @@
+# RFC: Key-Value Separation for Mini-LSM
+
+**Status**: Draft  
+**Author**: Mini-LSM Contributors  
+**Created**: 2026-03-08  
+**Target Version**: Post-Week 3  
+**Tracking Issue**: TBD
+
+---
+
+## Summary
+
+This RFC proposes adding key-value separation support to Mini-LSM, inspired by [WiscKey](https://www.usenix.org/system/files/conference/fast16/fast16-papers-lu.pdf) and production systems like BadgerDB and RocksDB's BlobDB. Key-value separation stores large values separately in dedicated Value Log (vLog) files while keeping keys and value pointers in the LSM tree. This significantly reduces write amplification and improves compaction performance for workloads with large values.
+
+## Motivation
+
+### Current Architecture Limitations
+
+In the current Mini-LSM implementation, both keys and values are stored together in SSTable blocks:
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Block Format (Current)                                     │
+├─────────────────────────────────────────────────────────────┤
+│  ┌──────────┬──────────┬────────┬──────────┬──────────┐    │
+│  │ key_len  │ key      │ val_len│ value    │ offset   │    │
+│  │ (2B)     │ (var)    │ (2B)   │ (var)    │ (2B)     │    │
+│  └──────────┴──────────┴────────┴──────────┴──────────┘    │
+└─────────────────────────────────────────────────────────────┘
+```
+
+This design has several issues with large values:
+
+1. **High Write Amplification**: During compaction, the entire key-value pair is rewritten even though keys are typically much smaller than values.
+2. **Inefficient Range Scans**: Range scans must read through large values even when only keys are needed.
+3. **Cache Pollution**: Large values consume block cache space inefficiently.
+4. **Slower Compaction**: Moving large amounts of data during compaction increases I/O pressure.
+
+### Example Scenario
+
+Consider a workload with:
+- Key size: 100 bytes
+- Value size: 10 KB
+- Total data: 10 GB (100M key-value pairs)
+
+With leveled compaction (amplification ~10x), the system writes ~100 GB during compactions. With key-value separation, only ~1 GB of keys are rewritten, reducing amplification by **10x**.
+
+## Design Overview
+
+### Value Log (vLog) Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    Key-Value Separation Architecture            │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│   LSM Tree (Keys + Value Pointers)                             │
+│   ┌─────────────────────────────────────────────────────────┐  │
+│   │  Key: "user:1001" → ValuePtr: {vlog_id: 5, offset: 1024}│  │
+│   │  Key: "user:1002" → ValuePtr: {vlog_id: 5, offset: 2048}│  │
+│   └─────────────────────────────────────────────────────────┘  │
+│                              │                                  │
+│                              ▼                                  │
+│   Value Log Files (.vlog)                                      │
+│   ┌─────────────────────────────────────────────────────────┐  │
+│   │  vlog_00001.vlog                                       │  │
+│   │  ┌──────────┬────────┬──────────┬──────────┬──────────┐ │  │
+│   │  │ checksum │ key_len│ key      │ val_len  │ value    │ │  │
+│   │  │ (4B)     │ (2B)   │ (var)    │ (4B)     │ (var)    │ │  │
+│   │  └──────────┴────────┴──────────┴──────────┴──────────┘ │  │
+│   └─────────────────────────────────────────────────────────┘  │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Key Components
+
+1. **ValueLog**: Manages value log files, handles writes and garbage collection
+2. **ValuePointer**: A reference to a value stored in vLog (file_id, offset, size)
+3. **ValueLogBuilder**: Builds vLog files during SSTable construction
+4. **GarbageCollector**: Reclaims space from stale values during compaction
+
+## Detailed Design
+
+### 1. Value Pointer Format
+
+```rust
+/// A pointer to a value stored in the Value Log.
+/// Stored inline in the LSM tree instead of the actual value.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ValuePointer {
+    /// Value log file ID
+    pub file_id: u32,
+    /// Offset within the file where the value starts
+    pub offset: u64,
+    /// Size of the encoded value entry (for validation)
+    pub size: u32,
+}
+
+impl ValuePointer {
+    /// Encode to bytes for storage in LSM tree
+    pub fn encode(&self, buf: &mut Vec<u8>) {
+        buf.put_u32(self.file_id);
+        buf.put_u64(self.offset);
+        buf.put_u32(self.size);
+    }
+
+    /// Decode from bytes
+    pub fn decode(mut buf: &[u8]) -> Self {
+        Self {
+            file_id: buf.get_u32(),
+            offset: buf.get_u64(),
+            size: buf.get_u32(),
+        }
+    }
+
+    /// Total encoded size: 16 bytes
+    pub const fn encoded_size() -> usize {
+        4 + 8 + 4 // 16 bytes
+    }
+}
+```
+
+### 2. Value Log File Format
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                    Value Log Entry Format                           │
+├─────────────────────────────────────────────────────────────────────┤
+│                                                                     │
+│  ┌───────────┬─────────┬───────────┬───────────┬───────────┐       │
+│  │ Header    │ Key     │ Value     │ Trailer   │ Padding   │       │
+│  │ (16 bytes)│ (var)   │ (var)     │ (4 bytes) │ (0-7 bytes)│       │
+│  └───────────┴─────────┴───────────┴───────────┴───────────┘       │
+│                                                                     │
+│  Header Format:                                                     │
+│  ┌─────────────┬───────────────┬─────────────┬──────────────┐      │
+│  │ crc32       │ key_length    │ value_length│ meta_flags   │      │
+│  │ (4 bytes)   │ (2 bytes)     │ (4 bytes)   │ (6 bytes)    │      │
+│  └─────────────┴───────────────┴─────────────┴──────────────┘      │
+│                                                                     │
+│  Trailer: CRC32 checksum of the entire entry (for validation)       │
+│                                                                     │
+│  Alignment: Entries are 8-byte aligned for efficient disk access    │
+│                                                                     │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+```rust
+/// Magic number for vLog file header
+const VLOG_MAGIC: u32 = 0x564C4F47; // "VLOG"
+
+/// Value log file header (first 16 bytes of each vLog file)
+#[derive(Clone, Debug)]
+pub struct VlogFileHeader {
+    pub magic: u32,
+    pub version: u16,
+    pub reserved: u10,
+}
+
+/// Entry header (precedes each key-value pair)
+#[repr(C, packed)]
+pub struct VlogEntryHeader {
+    pub crc32: u32,           // CRC32 of key + value
+    pub key_len: u16,         // Key length (max 64KB)
+    pub value_len: u32,       // Value length (max 4GB)
+    pub flags: u16,           // Flags (tombstone, etc.)
+}
+
+const HEADER_SIZE: usize = std::mem::size_of::<VlogEntryHeader>();
+const TRAILER_SIZE: usize = 4; // CRC32 checksum
+const ALIGNMENT: usize = 8;
+```
+
+### 3. ValueLog Module Structure
+
+```
+src/
+├── vlog/
+│   ├── mod.rs           # ValueLog manager
+│   ├── builder.rs       # ValueLogBuilder for constructing vLog files
+│   ├── reader.rs        # ValueLogReader for reading values
+│   └── gc.rs            # GarbageCollector for space reclamation
+```
+
+### 4. Configuration Options
+
+```rust
+#[derive(Clone, Debug)]
+pub struct ValueSeparationOptions {
+    /// Enable key-value separation
+    pub enabled: bool,
+    
+    /// Minimum value size to trigger separation (bytes)
+    /// Values smaller than this are stored inline
+    pub min_value_size: usize,
+    
+    /// Maximum size of a single vLog file
+    pub max_vlog_file_size: usize,
+    
+    /// Ratio of stale data to trigger garbage collection
+    pub gc_threshold_ratio: f64,
+    
+    /// Maximum number of vLog files to keep open
+    pub max_open_vlog_files: usize,
+}
+
+impl Default for ValueSeparationOptions {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            min_value_size: 1024,        // 1KB threshold
+            max_vlog_file_size: 64 << 20, // 64MB per vLog file
+            gc_threshold_ratio: 0.5,      // GC when 50% stale
+            max_open_vlog_files: 64,
+        }
+    }
+}
+```
+
+### 5. Modified SSTableBuilder
+
+```rust
+pub struct SsTableBuilder {
+    builder: BlockBuilder,
+    first_key: KeyVec,
+    last_key: KeyVec,
+    data: Vec<u8>,
+    pub(crate) meta: Vec<BlockMeta>,
+    block_size: usize,
+    key_hashes: Vec<u32>,
+    
+    // NEW: Value log components
+    vlog_options: Option<ValueSeparationOptions>,
+    vlog_builder: Option<ValueLogBuilder>,
+    current_vlog_id: u32,
+    vlog_entries: Vec<(ValuePointer, Bytes)>, // Pending entries
+}
+
+impl SsTableBuilder {
+    pub fn add(&mut self, key: KeySlice, value: &[u8]) {
+        if self.first_key.is_empty() {
+            self.first_key.set_from_slice(key);
+        }
+
+        self.key_hashes.push(farmhash::fingerprint32(key.raw_ref()));
+
+        // NEW: Check if value should be separated
+        let value_to_store = if self.should_separate_value(value) {
+            let vptr = self.write_to_vlog(key, value);
+            // Store the encoded pointer instead of the value
+            vptr.encode(&mut self.vlog_buffer);
+            &self.vlog_buffer[..ValuePointer::encoded_size()]
+        } else {
+            value
+        };
+
+        if self.builder.add(key, value_to_store) {
+            self.last_key.set_from_slice(key);
+            return;
+        }
+
+        self.finish_block();
+        assert!(self.builder.add(key, value_to_store));
+        self.last_key.set_from_slice(key);
+    }
+
+    fn should_separate_value(&self, value: &[u8]) -> bool {
+        match &self.vlog_options {
+            Some(opts) if opts.enabled => value.len() >= opts.min_value_size,
+            _ => false,
+        }
+    }
+}
+```
+
+### 6. ValueLog Implementation
+
+```rust
+/// Manages value log files for the storage engine.
+pub struct ValueLog {
+    /// Path to the vLog directory
+    path: PathBuf,
+    
+    /// Currently active vLog file for writing
+    active_writer: Mutex<ValueLogWriter>,
+    
+    /// Read cache for vLog files (file_id -> Arc<ValueLogReader>)
+    readers: moka::sync::Cache<u32, Arc<ValueLogReader>>,
+    
+    /// Next vLog file ID
+    next_file_id: AtomicU32,
+    
+    /// Configuration options
+    options: ValueSeparationOptions,
+    
+    /// Tracks which SSTs reference which vLog entries
+    /// Used for garbage collection
+    sst_to_vlogs: RwLock<HashMap<usize, HashSet<u32>>>,
+}
+
+impl ValueLog {
+    /// Write a key-value pair to the active vLog file.
+    /// Returns a ValuePointer that can be stored in the LSM tree.
+    pub fn write(&self, key: &[u8], value: &[u8]) -> Result<ValuePointer> {
+        let mut writer = self.active_writer.lock();
+        
+        // Rotate to new file if current is full
+        if writer.size() >= self.options.max_vlog_file_size {
+            writer = self.rotate_vlog_file(writer)?;
+        }
+        
+        writer.append(key, value)
+    }
+
+    /// Read a value using a ValuePointer.
+    pub fn read(&self, ptr: &ValuePointer) -> Result<Bytes> {
+        let reader = self.get_reader(ptr.file_id)?;
+        reader.read_at(ptr.offset, ptr.size)
+    }
+
+    /// Get a cached reader for the specified vLog file.
+    fn get_reader(&self, file_id: u32) -> Result<Arc<ValueLogReader>> {
+        self.readers.try_get_with(file_id, || {
+            ValueLogReader::open(self.path_of_file(file_id))
+        }).map_err(|e| anyhow!("Failed to open vlog {}: {}", file_id, e))
+    }
+}
+```
+
+### 7. Garbage Collection
+
+Garbage collection is triggered during compaction when the ratio of stale data exceeds a threshold.
+
+```rust
+/// Garbage collector for reclaiming space in value logs.
+pub struct GarbageCollector {
+    vlog: Arc<ValueLog>,
+    threshold: f64,
+}
+
+impl GarbageCollector {
+    /// Analyze a vLog file and determine which entries are still live.
+    /// Returns the ratio of live data.
+    pub fn analyze_file(&self, file_id: u32) -> Result<GcAnalysis> {
+        let reader = self.vlog.get_reader(file_id)?;
+        let mut live_entries = Vec::new();
+        let mut dead_bytes = 0;
+        let mut live_bytes = 0;
+
+        for entry in reader.iter() {
+            if self.is_entry_live(&entry)? {
+                live_entries.push(entry.ptr);
+                live_bytes += entry.size;
+            } else {
+                dead_bytes += entry.size;
+            }
+        }
+
+        let total = live_bytes + dead_bytes;
+        let live_ratio = if total > 0 { live_bytes as f64 / total as f64 } else { 1.0 };
+
+        Ok(GcAnalysis {
+            file_id,
+            live_ratio,
+            live_entries,
+            dead_bytes,
+        })
+    }
+
+    /// Rewrite live entries to a new vLog file and update pointers in SSTs.
+    pub fn compact_file(&self, analysis: &GcAnalysis) -> Result<()> {
+        if analysis.live_ratio > self.threshold {
+            return Ok(()); // No need to compact
+        }
+
+        // Create new vLog file with live entries
+        let new_file_id = self.vlog.next_file_id();
+        let mut writer = ValueLogWriter::create(self.vlog.path_of_file(new_file_id))?;
+        
+        // Map: old_ptr -> new_ptr
+        let mut pointer_map: HashMap<ValuePointer, ValuePointer> = HashMap::new();
+
+        for old_ptr in &analysis.live_entries {
+            let value = self.vlog.read(old_ptr)?;
+            let new_ptr = writer.append_raw(&value)?;
+            pointer_map.insert(*old_ptr, new_ptr);
+        }
+
+        writer.close()?;
+
+        // Update SSTs that reference this vLog file
+        self.update_sst_pointers(analysis.file_id, &pointer_map)?;
+
+        // Remove old vLog file
+        self.vlog.remove_file(analysis.file_id)?;
+
+        Ok(())
+    }
+
+    /// Check if a vLog entry is still referenced by the LSM tree.
+    fn is_entry_live(&self, entry: &VlogEntry) -> Result<bool> {
+        // Query the LSM tree to see if this key still references this vLog entry
+        let key = &entry.key;
+        match self.lsm.get(key)? {
+            Some(value) => {
+                // Decode value pointer and check if it matches
+                if value.len() == ValuePointer::encoded_size() {
+                    let ptr = ValuePointer::decode(&value);
+                    Ok(ptr.file_id == entry.ptr.file_id && ptr.offset == entry.ptr.offset)
+                } else {
+                    Ok(false) // Value is now inline
+                }
+            }
+            None => Ok(false), // Key was deleted
+        }
+    }
+}
+```
+
+### 8. Integration with Compaction
+
+```rust
+impl CompactionController {
+    /// After compaction, trigger garbage collection for affected vLog files.
+    pub fn post_compaction_gc(
+        &self,
+        input_ssts: &[usize],
+        output_ssts: &[usize],
+        vlog: &Arc<ValueLog>,
+    ) -> Result<()> {
+        // Collect all vLog files referenced by input SSTs
+        let mut affected_vlogs: HashSet<u32> = HashSet::new();
+        
+        for sst_id in input_ssts {
+            if let Some(vlogs) = vlog.get_sst_references(*sst_id) {
+                affected_vlogs.extend(vlogs);
+            }
+        }
+
+        // Run GC analysis on affected files
+        let gc = GarbageCollector::new(vlog.clone());
+        for file_id in affected_vlogs {
+            let analysis = gc.analyze_file(file_id)?;
+            if analysis.live_ratio < vlog.options().gc_threshold_ratio {
+                gc.compact_file(&analysis)?;
+            }
+        }
+
+        // Update references for output SSTs
+        for sst_id in output_ssts {
+            vlog.update_sst_references(*sst_id)?;
+        }
+
+        Ok(())
+    }
+}
+```
+
+## Implementation Plan
+
+### Phase 1: Core Infrastructure (Week 1)
+
+1. **ValuePointer and Encoding**
+   - Implement `ValuePointer` struct with serialization
+   - Add configuration options to `LsmStorageOptions`
+   - Create constants and shared types
+
+2. **ValueLog File Format**
+   - Implement vLog entry format with CRC32 checksums
+   - Create `VlogEntryHeader` and encoding/decoding
+   - Add alignment and padding logic
+
+3. **ValueLogWriter**
+   - Sequential write API for building vLog files
+   - File rotation when size limit reached
+   - Sync/flushing semantics
+
+4. **ValueLogReader**
+   - Random read API using file ID + offset
+   - Iterator interface for garbage collection
+   - Validation with checksums
+
+### Phase 2: SSTable Integration (Week 2)
+
+1. **Modified SSTableBuilder**
+   - Add `ValueLogBuilder` integration
+   - Threshold-based value separation
+   - Track which vLog files are referenced
+
+2. **Modified SsTable and SsTableIterator**
+   - Detect and decode `ValuePointer` values
+   - Transparent value fetching from vLog
+   - Iterator support for separated values
+
+3. **ValueLog Manager**
+   - Lifecycle management of vLog files
+   - Reference tracking from SSTs
+   - File caching and cleanup
+
+### Phase 3: Garbage Collection (Week 3)
+
+1. **GC Analysis**
+   - Scan vLog files to find live/dead entries
+   - Calculate space reclamation statistics
+   - Trigger policies
+
+2. **GC Execution**
+   - Rewrite live entries to new files
+   - Update SST value pointers
+   - Atomic file replacement
+
+3. **Background GC Thread**
+   - Optional background GC processing
+   - Rate limiting and I/O scheduling
+   - Progress tracking and metrics
+
+### Phase 4: Testing and Optimization (Week 4)
+
+1. **Unit Tests**
+   - Value pointer encoding/decoding
+   - vLog file format correctness
+   - GC correctness with various workloads
+
+2. **Integration Tests**
+   - End-to-end workflows
+   - Crash recovery testing
+   - Concurrent read/write scenarios
+
+3. **Performance Benchmarks**
+   - Compare with/without key-value separation
+   - Measure write amplification reduction
+   - Analyze read latency impact
+
+## API Changes
+
+### New Public Types
+
+```rust
+pub mod vlog {
+    pub struct ValuePointer { ... }
+    pub struct ValueSeparationOptions { ... }
+    pub struct ValueLogStats { ... }
+}
+```
+
+### Modified Types
+
+```rust
+pub struct LsmStorageOptions {
+    // ... existing fields ...
+    
+    /// Options for key-value separation
+    pub value_separation: ValueSeparationOptions,
+}
+```
+
+### New Storage Methods
+
+```rust
+impl MiniLsm {
+    /// Get statistics about value log usage
+    pub fn vlog_stats(&self) -> ValueLogStats;
+    
+    /// Trigger manual garbage collection
+    pub fn trigger_gc(&self) -> Result<()>;
+}
+```
+
+## Testing Strategy
+
+### Unit Tests
+
+```rust
+#[test]
+fn test_value_pointer_encoding() {
+    let ptr = ValuePointer {
+        file_id: 42,
+        offset: 1024,
+        size: 256,
+    };
+    let mut buf = Vec::new();
+    ptr.encode(&mut buf);
+    let decoded = ValuePointer::decode(&buf);
+    assert_eq!(ptr, decoded);
+}
+
+#[test]
+fn test_vlog_write_read() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let vlog = ValueLog::open(temp_dir.path(), Default::default()).unwrap();
+    
+    let key = b"test_key";
+    let value = vec![0u8; 4096]; // Large value
+    
+    let ptr = vlog.write(key, &value).unwrap();
+    let read_value = vlog.read(&ptr).unwrap();
+    
+    assert_eq!(value, read_value.as_ref());
+}
+```
+
+### Integration Tests
+
+```rust
+#[test]
+fn test_key_value_separation_workflow() {
+    let dir = tempfile::tempdir().unwrap();
+    let options = LsmStorageOptions {
+        value_separation: ValueSeparationOptions {
+            enabled: true,
+            min_value_size: 100,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    
+    let storage = MiniLsm::open(&dir, options).unwrap();
+    
+    // Write small value (inline)
+    storage.put(b"small", b"tiny").unwrap();
+    
+    // Write large value (separated)
+    let large_value = vec![0u8; 10000];
+    storage.put(b"large", &large_value).unwrap();
+    
+    // Force flush to create SST
+    storage.force_flush().unwrap();
+    
+    // Verify both values can be read
+    assert_eq!(storage.get(b"small").unwrap().unwrap(), b"tiny");
+    assert_eq!(storage.get(b"large").unwrap().unwrap(), large_value);
+}
+```
+
+## Compatibility and Migration
+
+### Forward Compatibility
+
+- Disabled by default in existing configurations
+- Can be enabled on existing databases (new writes use separation)
+- Existing inline values remain unchanged
+
+### Format Versioning
+
+```rust
+/// Database format version
+const FORMAT_VERSION: u32 = 2; // Increment from 1
+
+/// SSTable footer extension for vLog metadata
+pub struct SsTableFooter {
+    pub format_version: u32,
+    pub has_vlog_references: bool,
+    pub vlog_file_ids: Vec<u32>,
+}
+```
+
+### Manifest Changes
+
+```rust
+#[derive(Serialize, Deserialize)]
+pub enum ManifestRecord {
+    Flush(usize),
+    NewMemtable(usize),
+    Compaction(CompactionTask, Vec<usize>),
+    // NEW: Track vLog file lifecycle
+    NewVlogFile(u32),
+    DeleteVlogFile(u32),
+}
+```
+
+## Performance Considerations
+
+### Write Path
+
+| Operation | Latency Impact | Notes |
+|-----------|---------------|-------|
+| Small value (< threshold) | None | Stored inline as before |
+| Large value | +1 disk write | Sequential write to vLog |
+| Flush | Neutral | Sequential vLog writes are fast |
+
+### Read Path
+
+| Scenario | Latency Impact | Mitigation |
+|----------|---------------|------------|
+| Point get (large value) | +1 seek | vLog reader cache |
+| Range scan (keys only) | **Improved** | No value scanning |
+| Range scan (full) | Similar | Prefetching for sequential reads |
+
+### Compaction
+
+| Metric | Improvement |
+|--------|-------------|
+| Write amplification | 5-10x reduction for large values |
+| I/O throughput | ~10x improvement (less data moved) |
+| CPU usage | Reduced (smaller sorting) |
+
+## Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| vLog file corruption | Data loss | CRC32 checksums + validation |
+| GC overhead | Latency spikes | Background GC + rate limiting |
+| Space amplification | Temporary bloat | Configurable GC threshold |
+| Recovery complexity | Longer startup | vLog index + incremental recovery |
+
+## Future Work
+
+1. **Compression**: Compress values in vLog to reduce space
+2. **Hot/Cold Separation**: Tiered storage for frequently accessed values
+3. **Parallel GC**: Concurrent garbage collection across multiple files
+4. **vLog Index**: In-memory index for faster lookups
+5. **Value Caching**: Dedicated cache for hot values
+
+## References
+
+1. [WiscKey: Separating Keys from Values in SSD-conscious Storage](https://www.usenix.org/system/files/conference/fast16/fast16-papers-lu.pdf) - Lu et al., FAST 2016
+2. [BadgerDB Documentation](https://dgraph.io/docs/badger/design/) - Dgraph Labs
+3. [RocksDB BlobDB](https://github.com/facebook/rocksdb/wiki/BlobDB) - Facebook
+4. [Titan: A RocksDB Plugin for Large Values](https://pingcap.com/blog/titan-storage-engine-design-and-implementation) - PingCAP
+5. [Pebble Value Separation](https://www.cockroachlabs.com/blog/pebble-key-value-separation/) - Cockroach Labs
+
+---
+
+## Appendix A: File Layout
+
+```
+data/
+├── MANIFEST
+├── 00001.sst
+├── 00002.sst
+├── ...
+├── 00001.vlog      # NEW: Value log files
+├── 00002.vlog
+├── 00001.wal
+└── vlog_index/     # NEW: Optional vLog index
+    └── 00001.idx
+```
+
+## Appendix B: Configuration Examples
+
+### Development (low memory)
+
+```rust
+ValueSeparationOptions {
+    enabled: true,
+    min_value_size: 512,
+    max_vlog_file_size: 16 << 20,  // 16MB
+    gc_threshold_ratio: 0.3,       // Aggressive GC
+    max_open_vlog_files: 16,
+}
+```
+
+### Production (large values)
+
+```rust
+ValueSeparationOptions {
+    enabled: true,
+    min_value_size: 4096,          // 4KB
+    max_vlog_file_size: 256 << 20, // 256MB
+    gc_threshold_ratio: 0.5,
+    max_open_vlog_files: 128,
+}
+```
+
+### Disabled (backward compatible)
+
+```rust
+ValueSeparationOptions {
+    enabled: false,
+    ..Default::default()
+}
+```

--- a/rfcs/001-key-value-separation.md
+++ b/rfcs/001-key-value-separation.md
@@ -135,8 +135,8 @@ impl ValuePointer {
 │                                                                     │
 │  Header Format:                                                     │
 │  ┌─────────────┬───────────────┬─────────────┬──────────────┐      │
-│  │ crc32       │ key_length    │ value_length│ meta_flags   │      │
-│  │ (4 bytes)   │ (2 bytes)     │ (4 bytes)   │ (6 bytes)    │      │
+│  │ crc32       │ key_length    │ value_length│ flags        │ padding  │      │
+│  │ (4 bytes)   │ (2 bytes)     │ (4 bytes)   │ (2 bytes)    │ (4 bytes)│      │
 │  └─────────────┴───────────────┴─────────────┴──────────────┘      │
 │                                                                     │
 │  Trailer: CRC32 checksum of the entire entry (for validation)       │
@@ -153,18 +153,20 @@ const VLOG_MAGIC: u32 = 0x564C4F47; // "VLOG"
 /// Value log file header (first 16 bytes of each vLog file)
 #[derive(Clone, Debug)]
 pub struct VlogFileHeader {
-    pub magic: u32,
-    pub version: u16,
-    pub reserved: u10,
+    pub magic: u32,           // 4 bytes
+    pub version: u16,         // 2 bytes
+    pub reserved: [u8; 10],   // 10 bytes padding to align to 16 bytes total
 }
 
 /// Entry header (precedes each key-value pair)
-#[repr(C, packed)]
+/// Total size: 16 bytes for 8-byte alignment
+#[repr(C)]
 pub struct VlogEntryHeader {
-    pub crc32: u32,           // CRC32 of key + value
-    pub key_len: u16,         // Key length (max 64KB)
-    pub value_len: u32,       // Value length (max 4GB)
-    pub flags: u16,           // Flags (tombstone, etc.)
+    pub crc32: u32,           // CRC32 of key + value (4 bytes)
+    pub key_len: u16,         // Key length (max 64KB) (2 bytes)
+    pub value_len: u32,       // Value length (max 4GB) (4 bytes)
+    pub flags: u16,           // Flags (tombstone, etc.) (2 bytes)
+    pub _padding: [u8; 4],    // Padding to 16 bytes for alignment
 }
 
 const HEADER_SIZE: usize = std::mem::size_of::<VlogEntryHeader>();
@@ -208,8 +210,8 @@ pub struct ValueSeparationOptions {
 impl Default for ValueSeparationOptions {
     fn default() -> Self {
         Self {
-            enabled: true,
-            min_value_size: 1024,        // 1KB threshold
+            enabled: false,               // Disabled by default for backward compatibility
+            min_value_size: 1024,         // 1KB threshold
             max_vlog_file_size: 64 << 20, // 64MB per vLog file
             gc_threshold_ratio: 0.5,      // GC when 50% stale
             max_open_vlog_files: 64,
@@ -238,6 +240,11 @@ pub struct SsTableBuilder {
 }
 
 impl SsTableBuilder {
+    /// Tracks which vLog files are referenced by the SST being built.
+    /// Populated during add() when values are separated to vLog.
+    /// This is used to register the SST -> vLog mapping when the SST is finalized.
+    referenced_vlogs: HashSet<u32>,
+
     pub fn add(&mut self, key: KeySlice, value: &[u8]) {
         if self.first_key.is_empty() {
             self.first_key.set_from_slice(key);
@@ -249,6 +256,8 @@ impl SsTableBuilder {
         let value_to_store = if self.should_separate_value(value) {
             let vptr = self.write_to_vlog(key, value);
             // Store the encoded pointer instead of the value
+            // Clear buffer first to avoid accumulating encoded pointers
+            self.vlog_buffer.clear();
             vptr.encode(&mut self.vlog_buffer);
             &self.vlog_buffer[..ValuePointer::encoded_size()]
         } else {
@@ -296,6 +305,8 @@ pub struct ValueLog {
     
     /// Tracks which SSTs reference which vLog entries
     /// Used for garbage collection
+    /// Populated during SST build: when an SST is finalized, the vLog file IDs
+    /// it references are registered via register_sst_references()
     sst_to_vlogs: RwLock<HashMap<usize, HashSet<u32>>>,
 }
 
@@ -311,6 +322,35 @@ impl ValueLog {
         }
         
         writer.append(key, value)
+    }
+
+    /// Register SST -> vLog references when an SST is finalized.
+    /// This populates the sst_to_vlogs mapping for GC tracking.
+    pub fn register_sst_references(&self, sst_id: usize, vlog_ids: HashSet<u32>) {
+        let mut mapping = self.sst_to_vlogs.write();
+        mapping.insert(sst_id, vlog_ids);
+    }
+
+    /// Get all vLog files referenced by a given SST.
+    pub fn get_sst_references(&self, sst_id: usize) -> Option<HashSet<u32>> {
+        let mapping = self.sst_to_vlogs.read();
+        mapping.get(&sst_id).cloned()
+    }
+
+    /// Get all SSTs that reference a given vLog file.
+    /// Used during GC to find which SSTs need pointer updates.
+    pub fn get_ssts_referencing(&self, vlog_id: u32) -> Vec<usize> {
+        let mapping = self.sst_to_vlogs.read();
+        mapping
+            .iter()
+            .filter_map(|(sst_id, vlogs)| {
+                if vlogs.contains(&vlog_id) {
+                    Some(*sst_id)
+                } else {
+                    None
+                }
+            })
+            .collect()
     }
 
     /// Read a value using a ValuePointer.
@@ -336,10 +376,16 @@ Garbage collection is triggered during compaction when the ratio of stale data e
 /// Garbage collector for reclaiming space in value logs.
 pub struct GarbageCollector {
     vlog: Arc<ValueLog>,
+    lsm: Arc<MiniLsm>,  // Reference to LSM tree for liveness checks
     threshold: f64,
 }
 
 impl GarbageCollector {
+    /// Create a new garbage collector.
+    pub fn new(vlog: Arc<ValueLog>, lsm: Arc<MiniLsm>, threshold: f64) -> Self {
+        Self { vlog, lsm, threshold }
+    }
+
     /// Analyze a vLog file and determine which entries are still live.
     /// Returns the ratio of live data.
     pub fn analyze_file(&self, file_id: u32) -> Result<GcAnalysis> {
@@ -369,11 +415,10 @@ impl GarbageCollector {
     }
 
     /// Rewrite live entries to a new vLog file and update pointers in SSTs.
+    /// Note: This function assumes the caller has already checked that
+    /// analysis.live_ratio < threshold. The threshold check is done once
+    /// in the caller (post_compaction_gc) to avoid inconsistency.
     pub fn compact_file(&self, analysis: &GcAnalysis) -> Result<()> {
-        if analysis.live_ratio > self.threshold {
-            return Ok(()); // No need to compact
-        }
-
         // Create new vLog file with live entries
         let new_file_id = self.vlog.next_file_id();
         let mut writer = ValueLogWriter::create(self.vlog.path_of_file(new_file_id))?;
@@ -381,20 +426,52 @@ impl GarbageCollector {
         // Map: old_ptr -> new_ptr
         let mut pointer_map: HashMap<ValuePointer, ValuePointer> = HashMap::new();
 
-        for old_ptr in &analysis.live_entries {
-            let value = self.vlog.read(old_ptr)?;
-            let new_ptr = writer.append_raw(&value)?;
-            pointer_map.insert(*old_ptr, new_ptr);
+        // Rewrite live entries preserving both key and value
+        for entry in &analysis.live_entries {
+            // Must include the key for future GC liveness checks
+            let new_ptr = writer.append(&entry.key, &entry.value)?;
+            pointer_map.insert(entry.ptr, new_ptr);
         }
 
         writer.close()?;
 
         // Update SSTs that reference this vLog file
+        // This rewrites affected SSTs to update value pointers, which adds
+        // write amplification. The GC threshold should account for this cost.
         self.update_sst_pointers(analysis.file_id, &pointer_map)?;
 
         // Remove old vLog file
         self.vlog.remove_file(analysis.file_id)?;
 
+        Ok(())
+    }
+
+    /// Update value pointers in SSTs that reference the old vLog file.
+    /// This is expensive as it requires rewriting SSTs, but is necessary
+    /// because SSTs are immutable. The strategy:
+    /// 1. Find all SSTs referencing the old vLog file (using sst_to_vlogs)
+    /// 2. For each SST, read entries and rewrite with updated pointers
+    /// 3. Atomically replace old SSTs with new ones
+    /// 4. Update manifest to reflect new SST IDs
+    /// 
+    /// Performance note: To minimize write amplification, we batch SST updates
+    /// and only trigger this when the space savings justify the rewrite cost.
+    fn update_sst_pointers(
+        &self,
+        old_file_id: u32,
+        pointer_map: &HashMap<ValuePointer, ValuePointer>,
+    ) -> Result<()> {
+        // Get all SSTs referencing this vLog file
+        let affected_ssts = self.vlog.get_ssts_referencing(old_file_id);
+        
+        for sst_id in affected_ssts {
+            // Rewrite SST with updated pointers
+            let new_sst_id = self.rewrite_sst_with_new_pointers(sst_id, pointer_map)?;
+            
+            // Update manifest atomically
+            self.vlog.update_sst_reference(sst_id, new_sst_id, old_file_id)?;
+        }
+        
         Ok(())
     }
 
@@ -486,7 +563,8 @@ impl CompactionController {
 1. **Modified SSTableBuilder**
    - Add `ValueLogBuilder` integration
    - Threshold-based value separation
-   - Track which vLog files are referenced
+   - Track which vLog files are referenced via `referenced_vlogs: HashSet<u32>`
+   - Register SST -> vLog mapping via `register_sst_references()` when SST is finalized
 
 2. **Modified SsTable and SsTableIterator**
    - Detect and decode `ValuePointer` values

--- a/rfcs/001-key-value-separation.md
+++ b/rfcs/001-key-value-separation.md
@@ -281,15 +281,16 @@ impl ValueLogBuilder {
         let padded = (payload + ALIGNMENT - 1) & !(ALIGNMENT - 1);
         let pad = padded - payload;
 
-        self.writer.append_with_pad(key, value, pad);
-
-        debug_assert_eq!(self.writer.offset() % ALIGNMENT as u64, 0);
-
+        // Validate BEFORE writing to avoid corrupting the vLog with an oversized entry.
         assert!(
             padded <= u32::MAX as usize,
             "vLog entry size {} exceeds u32 capacity — increase max_value_size or reduce key/value size",
             padded
         );
+
+        self.writer.append_with_pad(key, value, pad);
+
+        debug_assert_eq!(self.writer.offset() % ALIGNMENT as u64, 0);
 
         ValuePointer {
             file_id: self.file_id,
@@ -369,7 +370,6 @@ pub struct SsTableBuilder {
     // `active_writer` during flush. Each concurrent flush gets its own file.
     vlog_options: Option<ValueSeparationOptions>,
     vlog_builder: Option<ValueLogBuilder>,
-    vlog_buffer: Vec<u8>,
     referenced_vlogs: HashSet<u32>,
 }
 
@@ -417,9 +417,13 @@ impl SsTableBuilder {
             (value, k)
         } else if self.should_separate_value(key, value) {
             let vptr = self.write_to_vlog(key, value);
-            self.vlog_buffer.clear();
-            vptr.encode(&mut self.vlog_buffer);
-            (&self.vlog_buffer[..ValuePointer::encoded_size()], KvKind::ValuePointer)
+            // Encode into a local Vec — avoids borrow checker conflict with
+            // self.finish_block() below (self.vlog_buffer would hold &mut self).
+            // The buffer is small (17 bytes) and only allocated on the separation
+            // path, so the cost is negligible.
+            let mut local_buf = Vec::with_capacity(ValuePointer::encoded_size());
+            vptr.encode(&mut local_buf);
+            return self.add_with_kind(key, &local_buf, Some(KvKind::ValuePointer));
         } else {
             (value, KvKind::Inline)
         };
@@ -1286,7 +1290,8 @@ The WAL stores full values for user writes, so crash recovery for the normal wri
 - **Partial vLog write**: detected by CRC32 mismatch and skipped during reads.
 
 **GC crash safety**: GC's `compact_file` fsyncs the new vLog BEFORE performing any CAS operations (Phase 1 → Phase 2 ordering). On crash:
-- **Before CAS is flushed to SST**: WAL replay restores the old ValuePointer (pre-CAS state). The new vLog file is orphaned but harmless — it will be cleaned up on the next GC pass or startup orphan sweep.
+- **Before CAS**: WAL replay restores the old ValuePointer (pre-CAS state). The new vLog file is orphaned but harmless — it will be cleaned up on the next GC pass or startup orphan sweep.
+- **After CAS, before SST flush**: WAL replay restores the NEW ValuePointer (post-CAS state). This is safe because the new vLog was fsynced before the CAS (Phase 1 ordering), so the pointer is always valid.
 - **After CAS is flushed to SST**: the new ValuePointer is durable in the SST. The new vLog file is referenced by the SST and will not be deleted.
 
 ### WAL Interaction
@@ -1309,7 +1314,7 @@ This design avoids the double-fsync problem entirely. The write path has exactly
 - **Crash before flush**: WAL replay rebuilds the memtable with full values — no vLog pointers to validate.
 - **Crash during flush**: the flush is atomic — either the SST (with valid vLog pointers) is committed to the manifest, or it is not. Partial vLog writes are detected by CRC32 mismatch and skipped.
 - **No dangling pointers**: because vLog writes are fsynced (batch, once per flush) before the SST is written, every `ValuePointer` in every SST is guaranteed to reference durable data.
-- **Orphan cleanup**: on startup, any `.vlog` file not referenced by the manifest or any SST is deleted.
+- **Orphan cleanup**: on startup, any `.vlog` file not referenced by the manifest, any SST, or the WAL-recovered memtable is deleted.
 
 ## Performance Considerations
 

--- a/rfcs/001-key-value-separation.md
+++ b/rfcs/001-key-value-separation.md
@@ -133,11 +133,11 @@ impl ValuePointer {
 │  │ (16 bytes)│ (var)   │ (var)     │ (4 bytes) │ (0-7 bytes)│       │
 │  └───────────┴─────────┴───────────┴───────────┴───────────┘       │
 │                                                                     │
-│  Header Format:                                                     │
-│  ┌─────────────┬───────────────┬─────────────┬──────────────┐      │
-│  │ crc32       │ key_length    │ value_length│ flags        │ padding  │      │
-│  │ (4 bytes)   │ (2 bytes)     │ (4 bytes)   │ (2 bytes)    │ (4 bytes)│      │
-│  └─────────────┴───────────────┴─────────────┴──────────────┘      │
+│  Header Format (16 bytes total):                                    │
+│  ┌─────────────┬───────────────┬─────────────┬─────────────┬──────────┐
+│  │ crc32       │ key_length    │ value_length│ flags       │ padding  │
+│  │ (4 bytes)   │ (2 bytes)     │ (4 bytes)   │ (2 bytes)   │ (4 bytes)│
+│  └─────────────┴───────────────┴─────────────┴─────────────┴──────────┘
 │                                                                     │
 │  Trailer: CRC32 checksum of the entire entry (for validation)       │
 │                                                                     │
@@ -516,7 +516,7 @@ impl CompactionController {
         }
 
         // Run GC analysis on affected files
-        let gc = GarbageCollector::new(vlog.clone());
+        let gc = GarbageCollector::new(vlog.clone(), self.lsm.clone(), vlog.options().gc_threshold_ratio);
         for file_id in affected_vlogs {
             let analysis = gc.analyze_file(file_id)?;
             if analysis.live_ratio < vlog.options().gc_threshold_ratio {
@@ -525,8 +525,11 @@ impl CompactionController {
         }
 
         // Update references for output SSTs
+        // Output SSTs register their vLog references during SST construction
+        // The SST builder calls register_sst_references() when finalizing each SST
         for sst_id in output_ssts {
-            vlog.update_sst_references(*sst_id)?;
+            // SSTs created during compaction will register themselves
+            // via their builder's referenced_vlogs set
         }
 
         Ok(())
@@ -686,7 +689,7 @@ fn test_key_value_separation_workflow() {
     let dir = tempfile::tempdir().unwrap();
     let options = LsmStorageOptions {
         value_separation: ValueSeparationOptions {
-            enabled: true,
+            enabled: true,                // Enable for this test
             min_value_size: 100,
             ..Default::default()
         },

--- a/rfcs/001-key-value-separation.md
+++ b/rfcs/001-key-value-separation.md
@@ -114,6 +114,13 @@ pub enum KvKind {
     /// The value is a 17-byte encoded `ValuePointer` that references the vLog.
     ValuePointer = 1,
 }
+// NOTE: KvKind is stored per-entry in SST block metadata (not in the
+// memtable or WAL). During normal writes the memtable stores full values,
+// so the read path never needs KvKind from the memtable. During GC rewrites
+// the memtable receives a ValuePointer entry — the reader distinguishes it
+// by the VALUE_POINTER_TAG prefix byte (0xFF) which is reserved and cannot
+// appear as the first byte of a valid user value. This avoids changing the
+// memtable/WAL format.
 
 impl KvKind {
     pub fn from_u8(v: u8) -> Option<Self> {
@@ -259,6 +266,13 @@ pub struct VlogEntryHeader {
     pub flags: u16,           // Flags (tombstone, etc.) (2 bytes)
     pub _padding: [u8; 4],    // Reserved / padding to a 16-byte total
 }
+// NOTE: The CRC32 covers the rest of the header + key + value, so a
+// header-only iterator (which skips the value payload) cannot validate
+// the checksum. To allow header-only validation and resynchronization
+// after corruption, the on-disk format should prepend a 4-byte magic
+// marker (e.g., 0x76_4C_6F_67 = "vLog") before each entry header.
+// A header-only scanner can then skip forward to the next magic marker
+// if the current header's fields are implausible (e.g., value_len > max).
 
 const HEADER_SIZE: usize = 16; // VlogEntryHeader is always 16 bytes
 const ALIGNMENT: usize = 8;
@@ -282,28 +296,28 @@ impl ValueLogBuilder {
     /// to the next `ALIGNMENT` (8-byte) boundary. The pad bytes are written to
     /// disk *and* counted in `ValuePointer::size`, so a reader can validate
     /// the entry and advance to the next one without re-reading the header.
-    pub fn add(&mut self, key: &[u8], value: &[u8]) -> ValuePointer {
+    pub fn add(&mut self, key: &[u8], value: &[u8]) -> Result<ValuePointer> {
         let offset = self.writer.offset();
 
         // Validate BEFORE writing to avoid corrupting the vLog with an oversized entry.
         let entry_size = HEADER_SIZE + key.len() + value.len();
         let padding = (ALIGNMENT - (entry_size % ALIGNMENT)) % ALIGNMENT;
         let total = entry_size + padding;
-        assert!(
+        anyhow::ensure!(
             total <= u32::MAX as usize,
             "vLog entry size {} exceeds u32 capacity — increase max_value_size or reduce key/value size",
             total
         );
 
-        let written = self.writer.append(key, value);
+        let written = self.writer.append(key, value)?;
         debug_assert_eq!(written, total);
         debug_assert_eq!(self.writer.offset() % ALIGNMENT as u64, 0);
 
-        ValuePointer {
+        Ok(ValuePointer {
             file_id: self.file_id,
             offset,
             size: total as u32,
-        }
+        })
     }
 }
 ```
@@ -389,8 +403,8 @@ impl SsTableBuilder {
     /// to the vLog and stores only the `ValuePointer` in the SST. The vLog is
     /// fsynced before the SST entry is written, so every pointer is durable.
     /// Backward-compatible wrapper: defaults to `input_kind = None` (flush path).
-    pub fn add(&mut self, key: KeySlice, value: &[u8]) {
-        self.add_with_kind(key, value, None);
+    pub fn add(&mut self, key: KeySlice, value: &[u8]) -> Result<()> {
+        self.add_with_kind(key, value, None)
     }
 
     /// Add a key-value pair to the builder with an explicit KvKind.
@@ -400,7 +414,7 @@ impl SsTableBuilder {
     /// When `input_kind` is `None` (flush path), this method writes large values
     /// to the vLog and stores only the `ValuePointer` in the SST. The vLog is
     /// fsynced before the SST file is written, so every pointer is durable.
-    pub fn add_with_kind(&mut self, key: KeySlice, value: &[u8], input_kind: Option<KvKind>) {
+    pub fn add_with_kind(&mut self, key: KeySlice, value: &[u8], input_kind: Option<KvKind>) -> Result<()> {
         if self.first_key.is_empty() {
             self.first_key.set_from_slice(key);
         }
@@ -428,7 +442,7 @@ impl SsTableBuilder {
             }
             (value, k)
         } else if self.should_separate_value(key, value) {
-            let vptr = self.write_to_vlog(key, value);
+            let vptr = self.write_to_vlog(key, value)?;
             // Encode into a local Vec — avoids borrow checker conflict with
             // self.finish_block() below. The buffer is small (17 bytes) and
             // only allocated on the separation path, so the cost is negligible.
@@ -443,20 +457,21 @@ impl SsTableBuilder {
         // reader can classify the value without guessing from the payload.
         if self.builder.add_with_kind(key, value_to_store, kind) {
             self.last_key.set_from_slice(key);
-            return;
+            return Ok(());
         }
 
         self.finish_block();
         self.first_key.set_from_slice(key);
         assert!(self.builder.add_with_kind(key, value_to_store, kind));
         self.last_key.set_from_slice(key);
+        Ok(())
     }
 
     /// Write a key-value pair to the active vLog builder and return a pointer.
-    fn write_to_vlog(&mut self, key: KeySlice, value: &[u8]) -> ValuePointer {
-        let ptr = self.vlog_builder.as_mut().unwrap().add(key.raw_ref(), value);
+    fn write_to_vlog(&mut self, key: KeySlice, value: &[u8]) -> Result<ValuePointer> {
+        let ptr = self.vlog_builder.as_mut().unwrap().add(key.raw_ref(), value)?;
         self.referenced_vlogs.insert(ptr.file_id);
-        ptr
+        Ok(ptr)
     }
 
     fn should_separate_value(&self, key: KeySlice, value: &[u8]) -> bool {
@@ -551,6 +566,10 @@ pub struct ValueLog {
     /// Used by `reclaim_pending_deletions` to ensure a file is not deleted
     /// while an iterator or snapshot still holds an open handle.
     reader_refcounts: RwLock<HashMap<u32, Arc<AtomicUsize>>>,
+
+    /// Reference to the manifest for writing NewVlogFile/DeleteVlogFile
+    /// records during file rotation and deletion.
+    manifest: Arc<Manifest>,
 }
 
 impl ValueLog {

--- a/rfcs/001-key-value-separation.md
+++ b/rfcs/001-key-value-separation.md
@@ -486,7 +486,7 @@ impl ValueLog {
         
         // Rotate to new file if current is full
         if writer.size() >= self.options.max_vlog_file_size {
-            writer = self.rotate_vlog_file(writer)?;
+            self.rotate_vlog_file(&mut writer)?;
         }
         
         writer.append(key, value)
@@ -530,9 +530,15 @@ impl ValueLog {
 
     /// Read a value using a ValuePointer. Returns only the value bytes
     /// (the caller never needs to see the vLog header or key).
-    pub fn read(self: &Arc<ValueLog>, ptr: &ValuePointer) -> Result<Bytes> {
+    /// `expected_key` is validated against the stored key to detect stale or
+    /// corrupted pointers that land on a different entry's offset.
+    pub fn read(self: &Arc<ValueLog>, ptr: &ValuePointer, expected_key: &[u8]) -> Result<Bytes> {
         let reader = self.get_reader(ptr.file_id)?;
         let entry = reader.read_entry(ptr.offset, ptr.size)?;
+        if entry.key != expected_key {
+            anyhow::bail!("vLog key mismatch at offset {}: expected {:?}, found {:?}",
+                ptr.offset, expected_key, entry.key);
+        }
         Ok(Bytes::from(entry.value))
     }
 
@@ -629,8 +635,8 @@ impl ValueLog {
                 && self.reader_refcount(p.file_id) == 0
                 && self.get_ssts_referencing(p.file_id).is_empty();
             if safe {
-                let _ = self.remove_file(p.file_id);
-                false // drop from queue
+                // Keep the entry in the queue if unlink fails so it can be retried.
+                self.remove_file(p.file_id).is_err()
             } else {
                 true // keep, retry later
             }
@@ -746,10 +752,12 @@ impl GarbageCollector {
             // overwritten. Implementations without explicit CAS can serialize
             // GC writes with the write batch lock and re-check `is_entry_live`
             // inside the critical section.
+            let mut expected_buf = Vec::with_capacity(ValuePointer::encoded_size());
+            entry.ptr.encode(&mut expected_buf);
             self.lsm.compare_and_set(
                 &entry.key,
-                /* expected = */ &entry.ptr,
-                /* new      = */ &buf,
+                &expected_buf,
+                &buf,
             )?;
         }
 

--- a/rfcs/001-key-value-separation.md
+++ b/rfcs/001-key-value-separation.md
@@ -131,6 +131,14 @@ impl KvKind {
 /// is not `0xFF`, the value is definitely not a pointer. However the
 /// authoritative classification comes from `KvKind` stored in the SST block
 /// metadata, because a user value can legitimately start with `0xFF`.
+/// Fast-path sanity byte prefix on encoded ValuePointers.
+/// With KvKind as authoritative SST metadata, this tag is technically redundant
+/// for classification. It is retained as a cheap corruption/desync detector:
+/// if a reader sees KvKind::ValuePointer but the payload doesn't start with
+/// 0xFF, something is wrong. The 1-byte overhead (17 vs 16 bytes) is negligible
+/// compared to the values it references. Removing it would save one byte per
+/// pointer but lose the cross-check; a future optimization can drop it if the
+/// encoded size becomes a bottleneck.
 const VALUE_POINTER_TAG: u8 = 0xFF;
 
 impl ValuePointer {
@@ -449,12 +457,13 @@ pub struct VlogReferences {
 }
 
 /// RAII guard for a cached vLog reader. Automatically decrements the
-/// ValueLog's reader_refcount when dropped, preventing retired vLog files
+/// per-file atomic refcount when dropped, preventing retired vLog files
 /// from being unlinked while an iterator or snapshot still reads them.
 pub struct ValueLogReaderHandle {
     reader: Arc<ValueLogReader>,
-    vlog: Arc<ValueLog>,  // Shared ref ensures increment/decrement hit the same map
+    vlog: Arc<ValueLog>,
     file_id: u32,
+    counter: Arc<AtomicUsize>,  // Per-file atomic — no global lock on increment/decrement
 }
 
 impl std::ops::Deref for ValueLogReaderHandle {
@@ -464,7 +473,7 @@ impl std::ops::Deref for ValueLogReaderHandle {
 
 impl Drop for ValueLogReaderHandle {
     fn drop(&mut self) {
-        self.vlog.release_reader(self.file_id);
+        self.vlog.release_reader(self.file_id, &self.counter);
     }
 }
 
@@ -504,7 +513,7 @@ pub struct ValueLog {
     /// `ValueLogReader` is fetched from the cache; decremented on drop.
     /// Used by `reclaim_pending_deletions` to ensure a file is not deleted
     /// while an iterator or snapshot still holds an open handle.
-    reader_refcounts: RwLock<HashMap<u32, usize>>,
+    reader_refcounts: RwLock<HashMap<u32, Arc<AtomicUsize>>>,
 }
 
 impl ValueLog {
@@ -588,26 +597,28 @@ impl ValueLog {
 
     /// Get a cached reader for the specified vLog file.
     /// Returns a RAII guard that decrements the refcount on drop.
-    /// `self_arc` is the `Arc<ValueLog>` that owns this instance (passed by caller
-    /// so the handle can share the same refcount map).
+    /// Uses per-file AtomicUsize to avoid global write-lock contention.
     fn get_reader(self: &Arc<ValueLog>, file_id: u32) -> Result<ValueLogReaderHandle> {
         let reader = self.readers.try_get_with(file_id, || {
             ValueLogReader::open(self.path_of_file(file_id)).map(Arc::new)
         }).map_err(|e| anyhow!("Failed to open vlog {}: {}", file_id, e))?;
-        // Track open-reader reference count for safe deferred deletion.
-        *self.reader_refcounts.write().entry(file_id).or_insert(0) += 1;
-        Ok(ValueLogReaderHandle { reader, vlog: self.clone(), file_id })
+        // Get or create per-file atomic counter. Write lock only on first access.
+        let counter = self.reader_refcounts
+            .write()
+            .entry(file_id)
+            .or_insert_with(|| Arc::new(AtomicUsize::new(0)))
+            .clone();
+        counter.fetch_add(1, Ordering::Relaxed);
+        Ok(ValueLogReaderHandle { reader, vlog: self.clone(), file_id, counter })
     }
 
     /// Decrements the reference count for a vLog file reader.
     /// Called when a `ValueLogReaderHandle` is dropped.
-    fn release_reader(&self, file_id: u32) {
-        let mut counts = self.reader_refcounts.write();
-        if let Some(count) = counts.get_mut(&file_id) {
-            *count = count.saturating_sub(1);
-            if *count == 0 {
-                counts.remove(&file_id);
-            }
+    fn release_reader(&self, file_id: u32, counter: &AtomicUsize) {
+        counter.fetch_sub(1, Ordering::Relaxed);
+        // Clean up map entry when count reaches zero (best-effort).
+        if counter.load(Ordering::Relaxed) == 0 {
+            self.reader_refcounts.write().remove(&file_id);
         }
     }
 
@@ -618,7 +629,7 @@ impl ValueLog {
         self.reader_refcounts
             .read()
             .get(&file_id)
-            .copied()
+            .map(|c| c.load(Ordering::Relaxed))
             .unwrap_or(0)
     }
 
@@ -1206,6 +1217,14 @@ Because vLog files are append-only and written before their corresponding SSTs, 
 3. **Recovery on restart**: The manifest is replayed as usual. Any vLog files referenced by SSTs in the manifest are valid. vLog files not referenced by any SST can be garbage collected on startup.
 4. **Partial vLog write**: If a crash occurs during vLog writing, the partially written entry is detected by CRC32 mismatch and skipped during reads.
 
+### WAL Interaction
+
+To avoid doubling write amplification by writing large values to both the WAL and the vLog, the WAL should store only the `ValuePointer` for separated values (not the full value). The vLog write is the durable copy; the WAL entry just records the pointer so recovery can reconstruct the memtable. This means:
+
+- **Write path**: value → vLog (durable) → WAL (pointer only) → memtable
+- **Recovery**: replay WAL; for entries with ValuePointer, the pointer is already correct — no vLog re-read needed
+- **Crash before vLog sync**: the WAL entry is also incomplete (write ordering), so the entry is lost — this is the same guarantee as a non-separated write
+
 ## Performance Considerations
 
 ### Write Path
@@ -1248,6 +1267,10 @@ Because vLog files are append-only and written before their corresponding SSTs, 
 3. **Parallel GC**: Concurrent garbage collection across multiple files
 4. **vLog Index**: In-memory index for faster lookups
 5. **Value Caching**: Dedicated cache for hot values
+6. **Batch GC CAS**: Batch `compare_and_set_with_kind` calls for live entries during GC to reduce atomic operation overhead and contention with user writes
+7. **Lock-free vLog writer**: Replace the `active_writer` Mutex with a lock-free append buffer, dedicated writer thread with request channel, or multiple active vLog files to improve write concurrency
+8. **Pre-created vLog rotation**: Prepare the next vLog file in the background so rotation doesn't block the writer with synchronous file creation
+9. **Remove VALUE_POINTER_TAG**: If the 1-byte tag overhead becomes a bottleneck, remove it and rely solely on KvKind for classification (encoded size drops from 17 to 16 bytes)
 
 ## References
 

--- a/rfcs/001-key-value-separation.md
+++ b/rfcs/001-key-value-separation.md
@@ -105,13 +105,25 @@ impl ValuePointer {
         buf.put_u32(self.size);
     }
 
-    /// Decode from bytes
+    /// Decode from bytes. Panics if the buffer is shorter than 16 bytes.
     pub fn decode(mut buf: &[u8]) -> Self {
+        assert!(buf.len() >= Self::encoded_size(), "ValuePointer buffer too short");
         Self {
             file_id: buf.get_u32(),
             offset: buf.get_u64(),
             size: buf.get_u32(),
         }
+    }
+
+    /// Try to decode from bytes. Returns None if the buffer is too short.
+    /// 
+    /// Note: In production, a type tag or prefix byte should be used to
+    /// unambiguously distinguish ValuePointer from inline 16-byte values.
+    pub fn try_decode(buf: &[u8]) -> Option<Self> {
+        if buf.len() < Self::encoded_size() {
+            return None;
+        }
+        Some(Self::decode(buf))
     }
 
     /// Total encoded size: 16 bytes
@@ -128,10 +140,10 @@ impl ValuePointer {
 │                    Value Log Entry Format                           │
 ├─────────────────────────────────────────────────────────────────────┤
 │                                                                     │
-│  ┌───────────┬─────────┬───────────┬───────────┬───────────┐       │
-│  │ Header    │ Key     │ Value     │ Trailer   │ Padding   │       │
-│  │ (16 bytes)│ (var)   │ (var)     │ (4 bytes) │ (0-7 bytes)│       │
-│  └───────────┴─────────┴───────────┴───────────┴───────────┘       │
+│  ┌───────────┬─────────┬───────────┬───────────┐                   │
+│  │ Header    │ Key     │ Value     │ Padding   │                   │
+│  │ (16 bytes)│ (var)   │ (var)     │ (0-7 bytes)│                  │
+│  └───────────┴─────────┴───────────┴───────────┘                   │
 │                                                                     │
 │  Header Format (16 bytes total):                                    │
 │  ┌─────────────┬───────────────┬─────────────┬─────────────┬──────────┐
@@ -139,7 +151,7 @@ impl ValuePointer {
 │  │ (4 bytes)   │ (2 bytes)     │ (4 bytes)   │ (2 bytes)   │ (4 bytes)│
 │  └─────────────┴───────────────┴─────────────┴─────────────┴──────────┘
 │                                                                     │
-│  Trailer: CRC32 checksum of the entire entry (for validation)       │
+│  CRC32: Covers key + value payload for integrity validation         │
 │                                                                     │
 │  Alignment: Entries are 8-byte aligned for efficient disk access    │
 │                                                                     │
@@ -170,7 +182,6 @@ pub struct VlogEntryHeader {
 }
 
 const HEADER_SIZE: usize = std::mem::size_of::<VlogEntryHeader>();
-const TRAILER_SIZE: usize = 4; // CRC32 checksum
 const ALIGNMENT: usize = 8;
 ```
 
@@ -193,7 +204,7 @@ impl ValueLogBuilder {
         ValuePointer {
             file_id: self.file_id,
             offset,
-            size: (key.len() + value.len() + HEADER_SIZE + TRAILER_SIZE) as u32,
+            size: (key.len() + value.len() + HEADER_SIZE) as u32,
         }
     }
 }
@@ -280,6 +291,11 @@ impl SsTableBuilder {
             vptr.encode(&mut self.vlog_buffer);
             &self.vlog_buffer[..ValuePointer::encoded_size()]
         } else {
+            // During compaction, values may already be encoded ValuePointers.
+            // Track their vLog references to prevent premature GC.
+            if let Some(vptr) = ValuePointer::try_decode(value) {
+                self.referenced_vlogs.insert(vptr.file_id);
+            }
             value
         };
 
@@ -289,6 +305,7 @@ impl SsTableBuilder {
         }
 
         self.finish_block();
+        self.first_key.set_from_slice(key);
         assert!(self.builder.add(key, value_to_store));
         self.last_key.set_from_slice(key);
     }
@@ -408,11 +425,20 @@ impl ValueLog {
     }
 
     /// Remove a vLog file from disk and invalidate the cache entry.
+    /// Only call this when no active snapshots or iterators reference the file.
     pub fn remove_file(&self, file_id: u32) -> Result<()> {
         let path = self.path_of_file(file_id);
         std::fs::remove_file(&path)?;
         self.readers.invalidate(&file_id);
         Ok(())
+    }
+
+    /// Schedule a vLog file for deletion once all readers are quiesced.
+    /// In production, this uses watermark-based epoch reclamation or reference counting.
+    pub fn schedule_deletion(&self, file_id: u32) -> Result<()> {
+        // TODO: integrate with snapshot watermark / epoch-based reclamation
+        // For now, defer to a background cleanup task that checks active snapshots.
+        self.remove_file(file_id)
     }
 }
 ```
@@ -518,8 +544,10 @@ impl GarbageCollector {
         // Ensure new vLog entries and LSM writes are durable before removing old file
         self.lsm.sync()?;
 
-        // Remove old vLog file and invalidate cache
-        self.vlog.remove_file(analysis.file_id)?;
+        // Defer deletion until all active snapshots/iterators referencing the old
+        // file have been released. In a production system, this uses reference
+        // counting or watermark-based epoch reclamation (see Stale Pointer Handling).
+        self.vlog.schedule_deletion(analysis.file_id)?;
 
         Ok(())
     }
@@ -528,11 +556,10 @@ impl GarbageCollector {
     fn is_entry_live(&self, entry: &VlogEntry) -> Result<bool> {
         match self.lsm.get(&entry.key)? {
             Some(value) => {
-                if value.len() == ValuePointer::encoded_size() {
-                    let ptr = ValuePointer::decode(&value);
+                if let Some(ptr) = ValuePointer::try_decode(&value) {
                     Ok(ptr.file_id == entry.ptr.file_id && ptr.offset == entry.ptr.offset)
                 } else {
-                    Ok(false) // Value is now inline
+                    Ok(false) // Value is now inline (or ambiguous 16-byte value)
                 }
             }
             None => Ok(false), // Key was deleted
@@ -554,6 +581,14 @@ If a `get()` reads a stale pointer from an old SST after the old vLog file has b
 1. All live entries are rewritten to the new vLog file
 2. The new pointers are durably written to the LSM tree (via `sync()`)
 3. No active snapshots or iterators are reading the old file
+
+**Deferred Deletion Strategy:**
+
+Production systems use one of the following approaches to safely reclaim old vLog files:
+
+- **Reference Counting**: Track open readers per vLog file. Delete when count reaches zero.
+- **Watermark-Based Reclamation**: Record the current MVCC watermark (minimum active snapshot timestamp) before GC. Only delete files after all snapshots older than that watermark have been released. This integrates naturally with Mini-LSM's Week 3 MVCC design.
+- **Epoch-Based Reclamation**: Similar to watermark, but using monotonic epoch counters for non-MVCC systems.
 ```
 
 ### 8. Integration with Compaction
@@ -649,9 +684,9 @@ impl CompactionController {
    - Trigger policies
 
 2. **GC Execution**
-   - Rewrite live entries to new files
-   - Update SST value pointers
-   - Atomic file replacement
+   - Rewrite live entries to new vLog files
+   - Re-insert updated pointers into LSM tree via normal writes
+   - Defer old file deletion until snapshots are quiesced
 
 3. **Background GC Thread**
    - Optional background GC processing

--- a/rfcs/001-key-value-separation.md
+++ b/rfcs/001-key-value-separation.md
@@ -277,6 +277,12 @@ impl ValueLogBuilder {
 
         debug_assert_eq!(self.writer.offset() % ALIGNMENT as u64, 0);
 
+        assert!(
+            padded <= u32::MAX as usize,
+            "vLog entry size {} exceeds u32 capacity — increase max_value_size or reduce key/value size",
+            padded
+        );
+
         ValuePointer {
             file_id: self.file_id,
             offset,
@@ -507,6 +513,13 @@ impl ValueLog {
     /// Delegates to ValueLogWriter::append which applies the same 8-byte
     /// alignment padding as ValueLogBuilder::add.
     pub fn write(&self, key: &[u8], value: &[u8]) -> Result<ValuePointer> {
+        // VlogEntryHeader.key_len is u16 — reject keys that would overflow.
+        anyhow::ensure!(
+            key.len() <= u16::MAX as usize,
+            "key length {} exceeds vLog header u16 capacity",
+            key.len()
+        );
+
         let mut writer = self.active_writer.lock();
 
         // Rotate to new file if current is full
@@ -729,20 +742,19 @@ impl GarbageCollector {
     /// Analyze a vLog file and determine which entries are still live.
     /// Returns the ratio of stale (dead) data.
     ///
-    /// Performance note: This performs an LSM `get()` for every entry in the vLog file.
-    /// For large vLog files this can be expensive. Consider scheduling GC during
-    /// low-traffic periods or processing files incrementally.
+    /// Uses a header-only iterator that reads only the header + key (skipping
+    /// the value payload) to avoid unnecessary I/O for large dead values.
+    /// The value is only read during compact_file for entries confirmed live.
     pub fn analyze_file(&self, file_id: u32) -> Result<GcAnalysis> {
         let reader = self.vlog.get_reader(file_id)?;
         let mut live_entries = Vec::new();
         let mut dead_bytes = 0;
         let mut live_bytes = 0;
 
-        for entry in reader.iter() {
-            let entry_size = entry.size;
-            if self.is_entry_live(&entry)? {
-                // Store only key + pointer, not the (potentially large) value.
-                live_entries.push(LiveEntryRef { ptr: entry.ptr, key: entry.key });
+        for meta in reader.iter_headers() {
+            let entry_size = meta.size;
+            if self.check_liveness(&meta.key, &meta.ptr)? {
+                live_entries.push(LiveEntryRef { ptr: meta.ptr, key: meta.key });
                 live_bytes += entry_size;
             } else {
                 dead_bytes += entry_size;
@@ -825,10 +837,16 @@ impl GarbageCollector {
     /// Uses KvKind (authoritative SST block metadata) to classify the current
     /// value, avoiding ambiguous payload-based pointer detection.
     fn is_entry_live(&self, entry: &VlogEntry) -> Result<bool> {
-        match self.lsm.get_with_kind(&entry.key)? {
+        self.check_liveness(&entry.key, &entry.ptr)
+    }
+
+    /// Liveness check using only key + pointer (no value needed).
+    /// Used by analyze_file's header-only iterator to avoid reading values.
+    fn check_liveness(&self, key: &[u8], ptr: &ValuePointer) -> Result<bool> {
+        match self.lsm.get_with_kind(key)? {
             Some((value, KvKind::ValuePointer)) => {
-                let ptr = ValuePointer::decode(&value)?;
-                Ok(ptr.file_id == entry.ptr.file_id && ptr.offset == entry.ptr.offset)
+                let current_ptr = ValuePointer::decode(&value)?;
+                Ok(current_ptr.file_id == ptr.file_id && current_ptr.offset == ptr.offset)
             }
             _ => Ok(false), // Key deleted, or value is now inline — entry is stale
         }
@@ -862,6 +880,12 @@ Production systems use one of the following approaches to safely reclaim old vLo
 ### 8. Integration with Compaction
 
 ```rust
+pub struct CompactionController {
+    /// Bounded thread pool for background GC work.
+    /// Prevents unbounded thread creation under sustained write load.
+    gc_pool: rayon::ThreadPool,
+}
+
 impl CompactionController {
     /// After compaction, schedule garbage collection for affected vLog files.
     /// GC runs asynchronously on a background thread to avoid blocking the
@@ -882,13 +906,12 @@ impl CompactionController {
             }
         }
 
-        // Schedule GC analysis on a background thread to avoid blocking compaction.
-        // The GC thread scans affected vLog files and rewrites live entries;
-        // doing this synchronously would add significant latency to the compaction
-        // pipeline, especially for large vLog files with many LSM lookups.
+        // Schedule GC on a bounded background worker to avoid blocking compaction.
+        // A single GC executor (or small thread pool) prevents unbounded thread
+        // creation under sustained write load where compactions outpace GC scans.
         let vlog = vlog.clone();
         let lsm = lsm.clone();
-        std::thread::spawn(move || {
+        self.gc_pool.spawn(move || {
             let gc = GarbageCollector::new(vlog.clone(), lsm, vlog.options().gc_threshold_ratio);
             for file_id in affected_vlogs {
                 if let Ok(analysis) = gc.analyze_file(file_id) {

--- a/rfcs/001-key-value-separation.md
+++ b/rfcs/001-key-value-separation.md
@@ -364,6 +364,9 @@ pub struct SsTableBuilder {
     key_hashes: Vec<u32>,
     
     // NEW: Value log components
+    // `vlog_builder` is a per-flush writer that allocates its own vLog file ID
+    // from `ValueLog::next_file_id()`. This avoids contention on the shared
+    // `active_writer` during flush. Each concurrent flush gets its own file.
     vlog_options: Option<ValueSeparationOptions>,
     vlog_builder: Option<ValueLogBuilder>,
     vlog_buffer: Vec<u8>,
@@ -374,6 +377,10 @@ impl SsTableBuilder {
     /// Add a key-value pair to the builder.
     /// `input_kind`: pass `Some(KvKind)` during compaction (from source SST metadata),
     /// or `None` for new writes (memtable flush) — the builder decides automatically.
+    ///
+    /// When `input_kind` is `None` (flush path), this method writes large values
+    /// to the vLog and stores only the `ValuePointer` in the SST. The vLog is
+    /// fsynced before the SST entry is written, so every pointer is durable.
     pub fn add(&mut self, key: KeySlice, value: &[u8], input_kind: Option<KvKind>) {
         if self.first_key.is_empty() {
             self.first_key.set_from_slice(key);
@@ -381,11 +388,13 @@ impl SsTableBuilder {
 
         self.key_hashes.push(farmhash::fingerprint32(key.raw_ref()));
 
-        // NEW: Determine value-to-store and KvKind.
+        // Determine value-to-store and KvKind.
         //
         // During compaction the caller passes `input_kind` from the source SST's
         // block metadata, so classification is authoritative — no payload sniffing.
-        // For new writes (memtable flush) `input_kind` is None and we decide here.
+        // During flush `input_kind` is None and we decide here: large values are
+        // written to the vLog (with fsync), and only the ValuePointer is stored
+        // in the SST.
         let (value_to_store, kind) = if let Some(k) = input_kind {
             // Compaction path: trust the caller's authoritative metadata.
             if k == KvKind::ValuePointer {
@@ -428,6 +437,7 @@ impl SsTableBuilder {
             Some(opts) if opts.enabled => {
                 // Keys stored in vLog must fit in the u16 key_len field
                 value.len() >= opts.min_value_size
+                    && value.len() <= opts.max_value_size
                     && key.raw_ref().len() <= u16::MAX as usize
             }
             _ => false,
@@ -519,6 +529,12 @@ pub struct ValueLog {
 impl ValueLog {
     /// Write a key-value pair to the active vLog file.
     /// Returns a ValuePointer that can be stored in the LSM tree.
+    ///
+    /// This is the primary write path for GC rewrites and any direct vLog
+    /// writes. The flush path uses `ValueLogBuilder` (owned by `SsTableBuilder`)
+    /// which writes to its own per-flush file; this method writes to the shared
+    /// `active_writer` and serializes via `active_writer.lock()`.
+    ///
     /// Delegates to ValueLogWriter::append which applies the same 8-byte
     /// alignment padding as ValueLogBuilder::add.
     pub fn write(&self, key: &[u8], value: &[u8]) -> Result<ValuePointer> {
@@ -677,7 +693,7 @@ impl ValueLog {
     /// SSTs. Instead the file is parked on a pending-deletion queue and a
     /// background task reclaims it once it is safe.
     ///
-    /// Safety condition (any one is sufficient):
+    /// Safety conditions (all required):
     /// - the file's reader/iterator refcount has dropped to zero, **and**
     /// - the MVCC watermark has advanced past the timestamp at which the file
     ///   was retired (so no snapshot can still hold a pointer into it), **and**
@@ -824,26 +840,39 @@ impl GarbageCollector {
         let new_file_id = self.vlog.next_file_id();
         let mut writer = ValueLogWriter::create(self.vlog.path_of_file(new_file_id))?;
 
-        // Rewrite live entries and update LSM index.
-        // Values are re-read from the vLog (not held in memory from analysis).
+        // Phase 1: Rewrite all live entries to the new vLog file.
+        // We collect the (key, old_ptr, new_ptr) tuples first, then fsync,
+        // then CAS — so every pointer we bind into the LSM already references
+        // durable vLog data.
+        let mut rewrites: Vec<(Vec<u8>, ValuePointer, ValuePointer)> = Vec::new();
         for entry_ref in &analysis.live_entries {
             let value = self.vlog.read(&entry_ref.ptr, &entry_ref.key)?;
             let new_ptr = writer.append(&entry_ref.key, &value)?;
+            rewrites.push((entry_ref.key.clone(), entry_ref.ptr, new_ptr));
+        }
+
+        // Fsync the new vLog BEFORE binding any pointers into the LSM tree.
+        // This prevents dangling pointers on crash: every ValuePointer we
+        // CAS into the memtable is already durable on disk.
+        writer.close()?;
+
+        // Phase 2: CAS each live key to point at the new vLog location.
+        for (key, old_ptr, new_ptr) in &rewrites {
             let mut buf = Vec::with_capacity(ValuePointer::encoded_size());
             new_ptr.encode(&mut buf);
 
             // Atomic rebind: only swap the pointer if the key still resolves
-            // to `entry.ptr`. `compare_and_set` performs the get + put under
+            // to `old_ptr`. `compare_and_set` performs the get + put under
             // the same MVCC sequence so a concurrent user write cannot be
             // overwritten. Implementations without explicit CAS can serialize
             // GC writes with the write batch lock and re-check `is_entry_live`
             // inside the critical section.
             let mut expected_buf = Vec::with_capacity(ValuePointer::encoded_size());
-            entry_ref.ptr.encode(&mut expected_buf);
+            old_ptr.encode(&mut expected_buf);
             // Kind-aware CAS: ensures we don't overwrite an inline user value
             // that happens to be byte-identical to the old pointer encoding.
             if !self.lsm.compare_and_set_with_kind(
-                &entry_ref.key,
+                key,
                 &expected_buf, KvKind::ValuePointer,
                 &buf, KvKind::ValuePointer,
             )? {
@@ -851,10 +880,7 @@ impl GarbageCollector {
             }
         }
 
-        writer.close()?;
-
-        // Ensure new vLog entries and LSM writes are durable before scheduling
-        // the old file for reclamation.
+        // Ensure LSM writes are durable before scheduling the old file for reclamation.
         self.lsm.sync()?;
 
         // Defer deletion until all active snapshots/iterators referencing the
@@ -1134,7 +1160,7 @@ fn test_vlog_write_read() {
     let value = vec![0u8; 4096]; // Large value
     
     let ptr = vlog.write(key, &value).unwrap();
-    let read_value = vlog.read(&ptr).unwrap();
+    let read_value = vlog.read(&ptr, key).unwrap();
     
     assert_eq!(value, read_value.as_ref());
 }
@@ -1160,11 +1186,11 @@ fn test_key_value_separation_workflow() {
     // Write small value (inline)
     storage.put(b"small", b"tiny").unwrap();
     
-    // Write large value (separated)
+    // Write large value — stored in WAL + memtable, separated to vLog on flush
     let large_value = vec![0u8; 10000];
     storage.put(b"large", &large_value).unwrap();
-    
-    // Force flush to create SST
+
+    // Force flush — this is where vLog write + separation happens
     storage.force_flush().unwrap();
     
     // Verify both values can be read
@@ -1231,24 +1257,39 @@ checks and by older snapshots whose manifest record predates this format.
 
 ## Crash Recovery
 
-Because vLog files are append-only and written before their corresponding SSTs, crash recovery follows these ordering rules:
+The WAL stores full values, so crash recovery does not depend on vLog pointers at all. Recovery proceeds in two phases:
 
-1. **vLog writes happen before SST writes**: When flushing a memtable, values are first appended to the vLog, then the SST is built with pointers to those vLog locations.
-2. **SST atomically installed**: The SST is only added to the LSM state (and manifest updated) after both vLog and SST files are fully written and synced.
-3. **Recovery on restart**: The manifest is replayed as usual. Any vLog files referenced by SSTs in the manifest are valid. vLog files not referenced by any SST can be garbage collected on startup.
-4. **Partial vLog write**: If a crash occurs during vLog writing, the partially written entry is detected by CRC32 mismatch and skipped during reads.
+1. **WAL replay**: rebuilds the memtable with full values — identical to a non-separated engine. No vLog validation needed.
+2. **Manifest replay**: for every `Flush` / `Compaction` record, call `register_sst_references(sst_id, vlog_ids)` to populate both `sst_to_vlogs` and `vlog_to_ssts` indexes.
+
+**Flush-time crash safety**: vLog writes are fsynced (batch, once per flush) before the SST is written to disk. If a crash occurs:
+- **Before SST is committed to manifest**: the flush is incomplete — the memtable (rebuilt from WAL) still contains the full values. The partially written vLog and SST files are orphaned.
+- **After SST is committed to manifest**: all vLog pointers in the SST are guaranteed valid (vLog was fsynced first).
+- **Partial vLog write**: detected by CRC32 mismatch and skipped during reads.
+
+**Orphan cleanup on startup**: after WAL and manifest replay, the engine scans the data directory for `.vlog` files. Any file not referenced by a `NewVlogFile` manifest record (or by an SST's vLog reference list) is orphaned and deleted. This handles vLog files from crashed flushes that were never committed to the manifest.
 
 ### WAL Interaction
 
-To avoid doubling write amplification by writing large values to both the WAL and the vLog, the WAL stores only the `ValuePointer` for separated values (not the full value). The vLog write must be synced **before** the WAL entry is committed to prevent dangling pointers on crash:
+The WAL stores the **full value** for every write — the same as a non-separated LSM tree. Value separation into the vLog happens **during flush** (memtable → SST), not during the put path:
 
-- **Write path**: value → vLog append → **vLog fsync** → WAL (pointer only) → **WAL fsync** → memtable
-- **Recovery**: replay WAL; for entries with ValuePointer, the pointer is already durable — no vLog re-read needed
-- **Crash before vLog fsync**: the WAL entry is also incomplete (write ordering), so the entry is lost — this is the same guarantee as a non-separated write
-- **Crash after WAL fsync**: vLog is guaranteed synced (ordering above), so the pointer is always valid
-- **Key invariant**: `fsync(vLog)` must complete before `write(WAL)` to prevent dangling pointers
+- **Write path (put)**: value → WAL (full value) → **WAL fsync** → memtable
+- **Flush path**: scan memtable → for each entry with `value.len() >= min_value_size`:
+  1. append value to vLog buffer (in-memory)
+  2. add `ValuePointer` to in-memory SST block
+  3. after all entries are processed: **vLog fsync** (once, batch)
+  4. write SST file to disk
+- **Small values** (< `min_value_size`): written inline to SST as before, no vLog involvement
 
-**Performance note**: the extra `sync()` call on the vLog adds latency per separated write. This can be amortized by batching multiple vLog appends before a single sync (group commit), which is the natural result of the Mutex on `active_writer`.
+This design avoids the double-fsync problem entirely. The write path has exactly one fsync (WAL), identical to a non-separated engine. The vLog fsync cost is paid once per flush (not per entry), which is a background operation and does not add latency to the put path.
+
+**Tradeoff**: the WAL now stores full values instead of 17-byte pointers, increasing WAL size and recovery time. For workloads with many large values, the WAL can grow significantly between flushes. This is mitigated by (a) frequent flushes (small memtable), and (b) the fact that WAL entries are deleted after flush.
+
+**Crash recovery**:
+- **Crash before flush**: WAL replay rebuilds the memtable with full values — no vLog pointers to validate.
+- **Crash during flush**: the flush is atomic — either the SST (with valid vLog pointers) is committed to the manifest, or it is not. Partial vLog writes are detected by CRC32 mismatch and skipped.
+- **No dangling pointers**: because vLog writes are fsynced (batch, once per flush) before the SST is written, every `ValuePointer` in every SST is guaranteed to reference durable data.
+- **Orphan cleanup**: on startup, any `.vlog` file not referenced by the manifest or any SST is deleted.
 
 ## Performance Considerations
 
@@ -1256,9 +1297,9 @@ To avoid doubling write amplification by writing large values to both the WAL an
 
 | Operation | Latency Impact | Notes |
 |-----------|---------------|-------|
-| Small value (< threshold) | None | Stored inline as before |
-| Large value | +1 disk write | Sequential write to vLog |
-| Flush | Neutral | Sequential vLog writes are fast |
+| Small value (< threshold) | None | Stored inline, same as non-separated |
+| Large value | None | Full value goes to WAL + memtable, no vLog on write path |
+| Flush (background) | +1 fsync per flush (batch) | vLog fsync once before SST write; does not block put path |
 
 ### Read Path
 
@@ -1330,6 +1371,7 @@ data/
 ValueSeparationOptions {
     enabled: true,
     min_value_size: 512,
+    max_value_size: 128 << 20,     // 128MB
     max_vlog_file_size: 16 << 20,  // 16MB
     gc_threshold_ratio: 0.3,       // Aggressive GC
     max_open_vlog_files: 16,
@@ -1342,6 +1384,7 @@ ValueSeparationOptions {
 ValueSeparationOptions {
     enabled: true,
     min_value_size: 4096,          // 4KB
+    max_value_size: 128 << 20,     // 128MB
     max_vlog_file_size: 256 << 20, // 256MB
     gc_threshold_ratio: 0.5,
     max_open_vlog_files: 128,

--- a/rfcs/001-key-value-separation.md
+++ b/rfcs/001-key-value-separation.md
@@ -93,7 +93,9 @@ pub struct ValuePointer {
     pub file_id: u32,
     /// Offset within the file where the value starts
     pub offset: u64,
-    /// Size of the encoded value entry (for validation)
+    /// Total size of the encoded entry on disk (header + key + value + padding).
+    /// u32 limits individual entries to ~4GB. In practice, max_value_size should
+    /// be set well below this (e.g., 128MB) to keep GC scan times reasonable.
     pub size: u32,
 }
 
@@ -302,17 +304,21 @@ src/
 pub struct ValueSeparationOptions {
     /// Enable key-value separation
     pub enabled: bool,
-    
+
     /// Minimum value size to trigger separation (bytes)
     /// Values smaller than this are stored inline
     pub min_value_size: usize,
-    
+
+    /// Maximum size of a single value (bytes). Must fit in u32 after
+    /// header + key + padding are added. Recommended: 128MB or less.
+    pub max_value_size: usize,
+
     /// Maximum size of a single vLog file
     pub max_vlog_file_size: usize,
-    
+
     /// Ratio of stale data to trigger garbage collection
     pub gc_threshold_ratio: f64,
-    
+
     /// Maximum number of vLog files to keep open
     pub max_open_vlog_files: usize,
 }
@@ -322,6 +328,7 @@ impl Default for ValueSeparationOptions {
         Self {
             enabled: false,               // Disabled by default for backward compatibility
             min_value_size: 1024,         // 1KB threshold
+            max_value_size: 128 << 20,    // 128MB max per value (well under u32 overflow)
             max_vlog_file_size: 64 << 20, // 64MB per vLog file
             gc_threshold_ratio: 0.5,      // GC when 50% stale
             max_open_vlog_files: 64,
@@ -497,14 +504,16 @@ pub struct ValueLog {
 impl ValueLog {
     /// Write a key-value pair to the active vLog file.
     /// Returns a ValuePointer that can be stored in the LSM tree.
+    /// Delegates to ValueLogWriter::append which applies the same 8-byte
+    /// alignment padding as ValueLogBuilder::add.
     pub fn write(&self, key: &[u8], value: &[u8]) -> Result<ValuePointer> {
         let mut writer = self.active_writer.lock();
-        
+
         // Rotate to new file if current is full
         if writer.size() >= self.options.max_vlog_file_size {
             self.rotate_vlog_file(&mut writer)?;
         }
-        
+
         writer.append(key, value)
     }
 
@@ -854,7 +863,9 @@ Production systems use one of the following approaches to safely reclaim old vLo
 
 ```rust
 impl CompactionController {
-    /// After compaction, trigger garbage collection for affected vLog files.
+    /// After compaction, schedule garbage collection for affected vLog files.
+    /// GC runs asynchronously on a background thread to avoid blocking the
+    /// compaction pipeline with vLog scanning and LSM lookups.
     pub fn post_compaction_gc(
         &self,
         input_ssts: &[usize],
@@ -871,21 +882,30 @@ impl CompactionController {
             }
         }
 
-        // Run GC analysis on affected files
-        let gc = GarbageCollector::new(vlog.clone(), lsm.clone(), vlog.options().gc_threshold_ratio);
-        for file_id in affected_vlogs {
-            let analysis = gc.analyze_file(file_id)?;
-            if analysis.stale_ratio >= vlog.options().gc_threshold_ratio {
-                gc.compact_file(&analysis)?;
+        // Schedule GC analysis on a background thread to avoid blocking compaction.
+        // The GC thread scans affected vLog files and rewrites live entries;
+        // doing this synchronously would add significant latency to the compaction
+        // pipeline, especially for large vLog files with many LSM lookups.
+        let vlog = vlog.clone();
+        let lsm = lsm.clone();
+        std::thread::spawn(move || {
+            let gc = GarbageCollector::new(vlog.clone(), lsm, vlog.options().gc_threshold_ratio);
+            for file_id in affected_vlogs {
+                if let Ok(analysis) = gc.analyze_file(file_id) {
+                    if analysis.stale_ratio >= vlog.options().gc_threshold_ratio {
+                        let _ = gc.compact_file(&analysis);
+                    }
+                }
             }
-        }
+        });
 
         // Register vLog references for output SSTs.
-        // In practice, each output SST is built by an SsTableBuilder which already
-        // populates referenced_vlogs. When the SST is finalized, the builder's
-        // referenced_vlogs set is passed to vlog.register_sst_references().
+        // SsTableBuilder is a low-level component without access to ValueLog.
+        // Registration is handled by the storage engine (LsmStorageInner) when
+        // it receives the finalized SST: the builder exposes its referenced_vlogs
+        // set via a getter, and the engine calls vlog.register_sst_references().
         for sst_id in output_ssts {
-            // SST builders register references automatically during finalization.
+            // Engine registers: builder.get_referenced_vlogs() → vlog.register_sst_references(sst_id, vlogs)
         }
 
         // Clean up vLog references for input SSTs that are being replaced.

--- a/rfcs/001-key-value-separation.md
+++ b/rfcs/001-key-value-separation.md
@@ -343,32 +343,36 @@ pub struct SsTableBuilder {
 }
 
 impl SsTableBuilder {
-    pub fn add(&mut self, key: KeySlice, value: &[u8]) {
+    /// Add a key-value pair to the builder.
+    /// `input_kind`: pass `Some(KvKind)` during compaction (from source SST metadata),
+    /// or `None` for new writes (memtable flush) — the builder decides automatically.
+    pub fn add(&mut self, key: KeySlice, value: &[u8], input_kind: Option<KvKind>) {
         if self.first_key.is_empty() {
             self.first_key.set_from_slice(key);
         }
 
         self.key_hashes.push(farmhash::fingerprint32(key.raw_ref()));
 
-        // NEW: Check if value should be separated and annotate with KvKind
-        let (value_to_store, kind) = if self.should_separate_value(key, value) {
+        // NEW: Determine value-to-store and KvKind.
+        //
+        // During compaction the caller passes `input_kind` from the source SST's
+        // block metadata, so classification is authoritative — no payload sniffing.
+        // For new writes (memtable flush) `input_kind` is None and we decide here.
+        let (value_to_store, kind) = if let Some(k) = input_kind {
+            // Compaction path: trust the caller's authoritative metadata.
+            if k == KvKind::ValuePointer {
+                if let Some(vptr) = ValuePointer::try_decode(value) {
+                    self.referenced_vlogs.insert(vptr.file_id);
+                }
+            }
+            (value, k)
+        } else if self.should_separate_value(key, value) {
             let vptr = self.write_to_vlog(key, value);
-            // Store the encoded pointer instead of the value
             self.vlog_buffer.clear();
             vptr.encode(&mut self.vlog_buffer);
             (&self.vlog_buffer[..ValuePointer::encoded_size()], KvKind::ValuePointer)
         } else {
-            // During compaction, values may already be encoded ValuePointers.
-            // Detect existing pointers and preserve KvKind so readers dereference
-            // them correctly instead of returning raw pointer bytes.
-            let mut kind = KvKind::Inline;
-            if value.len() == ValuePointer::encoded_size() && value[0] == VALUE_POINTER_TAG {
-                if let Some(vptr) = ValuePointer::try_decode(value) {
-                    self.referenced_vlogs.insert(vptr.file_id);
-                    kind = KvKind::ValuePointer;
-                }
-            }
-            (value, kind)
+            (value, KvKind::Inline)
         };
 
         // Each block entry now carries (key, value, KvKind) so that the
@@ -420,7 +424,7 @@ pub struct PendingDeletion {
 /// from being unlinked while an iterator or snapshot still reads them.
 pub struct ValueLogReaderHandle {
     reader: Arc<ValueLogReader>,
-    vlog: ValueLog,  // Clone (Arc-backed) for drop-time release
+    vlog: Arc<ValueLog>,  // Shared ref ensures increment/decrement hit the same map
     file_id: u32,
 }
 
@@ -517,17 +521,26 @@ impl ValueLog {
             .collect()
     }
 
+    /// Remove all vLog references for a deleted SST.
+    /// Must be called whenever an SST is removed (compaction, manual deletion)
+    /// to prevent stale entries in sst_to_vlogs from blocking vLog reclamation.
+    pub fn unregister_sst_references(&self, sst_id: usize) {
+        self.sst_to_vlogs.write().remove(&sst_id);
+    }
+
     /// Read a value using a ValuePointer. Returns only the value bytes
     /// (the caller never needs to see the vLog header or key).
-    pub fn read(&self, ptr: &ValuePointer) -> Result<Bytes> {
+    pub fn read(self: &Arc<ValueLog>, ptr: &ValuePointer) -> Result<Bytes> {
         let reader = self.get_reader(ptr.file_id)?;
         let entry = reader.read_entry(ptr.offset, ptr.size)?;
-        Ok(entry.value.freeze())
+        Ok(Bytes::from(entry.value))
     }
 
     /// Get a cached reader for the specified vLog file.
     /// Returns a RAII guard that decrements the refcount on drop.
-    fn get_reader(&self, file_id: u32) -> Result<ValueLogReaderHandle> {
+    /// `self_arc` is the `Arc<ValueLog>` that owns this instance (passed by caller
+    /// so the handle can share the same refcount map).
+    fn get_reader(self: &Arc<ValueLog>, file_id: u32) -> Result<ValueLogReaderHandle> {
         let reader = self.readers.try_get_with(file_id, || {
             ValueLogReader::open(self.path_of_file(file_id)).map(Arc::new)
         }).map_err(|e| anyhow!("Failed to open vlog {}: {}", file_id, e))?;
@@ -952,9 +965,14 @@ pub struct LsmStorageOptions {
 impl MiniLsm {
     /// Get statistics about value log usage
     pub fn vlog_stats(&self) -> ValueLogStats;
-    
+
     /// Trigger manual garbage collection
     pub fn trigger_gc(&self) -> Result<()>;
+
+    /// Atomically replace `key` only if the current value equals `old`.
+    /// Returns true if the swap succeeded, false if the value changed.
+    /// Used by GC to avoid overwriting fresher user writes during re-insertion.
+    pub fn compare_and_set(&self, key: &[u8], old: &[u8], new: &[u8]) -> Result<bool>;
 }
 ```
 

--- a/rfcs/001-key-value-separation.md
+++ b/rfcs/001-key-value-separation.md
@@ -662,10 +662,12 @@ impl ValueLog {
 
     /// Remove a vLog file from disk and invalidate the cache entry.
     /// Only call this when no active snapshots or iterators reference the file.
+    /// Cache is invalidated BEFORE unlink to prevent new readers from opening
+    /// a file that's about to be deleted.
     pub fn remove_file(&self, file_id: u32) -> Result<()> {
+        self.readers.invalidate(&file_id);
         let path = self.path_of_file(file_id);
         std::fs::remove_file(&path)?;
-        self.readers.invalidate(&file_id);
         Ok(())
     }
 
@@ -1240,10 +1242,11 @@ Because vLog files are append-only and written before their corresponding SSTs, 
 
 To avoid doubling write amplification by writing large values to both the WAL and the vLog, the WAL stores only the `ValuePointer` for separated values (not the full value). The vLog write must be synced **before** the WAL entry is committed to prevent dangling pointers on crash:
 
-- **Write path**: value → vLog append → **vLog sync** → WAL (pointer only) → memtable
+- **Write path**: value → vLog append → **vLog fsync** → WAL (pointer only) → **WAL fsync** → memtable
 - **Recovery**: replay WAL; for entries with ValuePointer, the pointer is already durable — no vLog re-read needed
-- **Crash before vLog sync**: the WAL entry is also incomplete (write ordering), so the entry is lost — this is the same guarantee as a non-separated write
-- **Crash after WAL commit**: vLog is guaranteed synced (ordering above), so the pointer is always valid
+- **Crash before vLog fsync**: the WAL entry is also incomplete (write ordering), so the entry is lost — this is the same guarantee as a non-separated write
+- **Crash after WAL fsync**: vLog is guaranteed synced (ordering above), so the pointer is always valid
+- **Key invariant**: `fsync(vLog)` must complete before `write(WAL)` to prevent dangling pointers
 
 **Performance note**: the extra `sync()` call on the vLog adds latency per separated write. This can be amortized by batching multiple vLog appends before a single sync (group commit), which is the natural result of the Mutex on `active_writer`.
 

--- a/rfcs/001-key-value-separation.md
+++ b/rfcs/001-key-value-separation.md
@@ -461,6 +461,10 @@ pub struct ValueLog {
     /// it references are registered via register_sst_references().
     sst_to_vlogs: RwLock<HashMap<usize, HashSet<u32>>>,
 
+    /// Reverse index: vLog file ID → set of SSTs referencing it.
+    /// Kept in sync with sst_to_vlogs for O(1) lookups during GC.
+    vlog_to_ssts: RwLock<HashMap<u32, HashSet<usize>>>,
+
     /// Monotonic clock / timestamp provider (shared with the LSM engine).
     /// Used by `schedule_deletion` to stamp each retired file with the
     /// current MVCC epoch so the deferred-reclamation pass can compare it
@@ -493,10 +497,12 @@ impl ValueLog {
     }
 
     /// Register SST -> vLog references when an SST is finalized.
-    /// This populates the sst_to_vlogs mapping for GC tracking.
+    /// Updates both forward (sst_to_vlogs) and reverse (vlog_to_ssts) indexes.
     pub fn register_sst_references(&self, sst_id: usize, vlog_ids: HashSet<u32>) {
-        let mut mapping = self.sst_to_vlogs.write();
-        mapping.insert(sst_id, vlog_ids);
+        for vlog_id in &vlog_ids {
+            self.vlog_to_ssts.write().entry(*vlog_id).or_default().insert(sst_id);
+        }
+        self.sst_to_vlogs.write().insert(sst_id, vlog_ids);
     }
 
     /// Get all vLog files referenced by a given SST.
@@ -506,26 +512,29 @@ impl ValueLog {
     }
 
     /// Get all SSTs that reference a given vLog file.
-    /// Used during GC to find which SSTs need pointer updates.
+    /// Uses the reverse index for O(1) lookup.
     pub fn get_ssts_referencing(&self, vlog_id: u32) -> Vec<usize> {
-        let mapping = self.sst_to_vlogs.read();
-        mapping
-            .iter()
-            .filter_map(|(sst_id, vlogs)| {
-                if vlogs.contains(&vlog_id) {
-                    Some(*sst_id)
-                } else {
-                    None
-                }
-            })
-            .collect()
+        self.vlog_to_ssts
+            .read()
+            .get(&vlog_id)
+            .map(|ssts| ssts.iter().copied().collect())
+            .unwrap_or_default()
     }
 
     /// Remove all vLog references for a deleted SST.
-    /// Must be called whenever an SST is removed (compaction, manual deletion)
-    /// to prevent stale entries in sst_to_vlogs from blocking vLog reclamation.
+    /// Updates both forward and reverse indexes.
     pub fn unregister_sst_references(&self, sst_id: usize) {
-        self.sst_to_vlogs.write().remove(&sst_id);
+        if let Some(vlog_ids) = self.sst_to_vlogs.write().remove(&sst_id) {
+            let mut reverse = self.vlog_to_ssts.write();
+            for vlog_id in vlog_ids {
+                if let Some(ssts) = reverse.get_mut(&vlog_id) {
+                    ssts.remove(&sst_id);
+                    if ssts.is_empty() {
+                        reverse.remove(&vlog_id);
+                    }
+                }
+            }
+        }
     }
 
     /// Read a value using a ValuePointer. Returns only the value bytes
@@ -754,11 +763,13 @@ impl GarbageCollector {
             // inside the critical section.
             let mut expected_buf = Vec::with_capacity(ValuePointer::encoded_size());
             entry.ptr.encode(&mut expected_buf);
-            self.lsm.compare_and_set(
+            if !self.lsm.compare_and_set(
                 &entry.key,
                 &expected_buf,
                 &buf,
-            )?;
+            )? {
+                continue; // A concurrent user write changed the value — skip this entry
+            }
         }
 
         writer.close()?;
@@ -776,16 +787,15 @@ impl GarbageCollector {
     }
 
     /// Check if a vLog entry is still referenced by the LSM tree.
+    /// Uses KvKind (authoritative SST block metadata) to classify the current
+    /// value, avoiding ambiguous payload-based pointer detection.
     fn is_entry_live(&self, entry: &VlogEntry) -> Result<bool> {
-        match self.lsm.get(&entry.key)? {
-            Some(value) => {
-                if let Some(ptr) = ValuePointer::try_decode(&value) {
-                    Ok(ptr.file_id == entry.ptr.file_id && ptr.offset == entry.ptr.offset)
-                } else {
-                    Ok(false) // Value is now inline (untagged) — not a pointer
-                }
+        match self.lsm.get_with_kind(&entry.key)? {
+            Some((value, KvKind::ValuePointer)) => {
+                let ptr = ValuePointer::decode(&value)?;
+                Ok(ptr.file_id == entry.ptr.file_id && ptr.offset == entry.ptr.offset)
             }
-            None => Ok(false), // Key was deleted
+            _ => Ok(false), // Key deleted, or value is now inline — entry is stale
         }
     }
 }
@@ -974,6 +984,11 @@ impl MiniLsm {
     /// Get statistics about value log usage
     pub fn vlog_stats(&self) -> ValueLogStats;
 
+    /// Get a value along with its authoritative KvKind metadata from SST blocks.
+    /// Returns None if the key is deleted. Used by GC's is_entry_live() to avoid
+    /// ambiguous payload-based pointer detection.
+    pub fn get_with_kind(&self, key: &[u8]) -> Result<Option<(Bytes, KvKind)>>;
+
     /// Trigger manual garbage collection
     pub fn trigger_gc(&self) -> Result<()>;
 
@@ -1084,14 +1099,15 @@ O(total SST count) once vLog adoption grows.
 pub enum ManifestRecord {
     /// Flush of a memtable to L0. Carries the vLog files this new SST
     /// references (empty if the SST has no separated values).
-    Flush(usize, Vec<u32>),
+    /// `#[serde(default)]` ensures old manifests without vLog data still parse.
+    Flush(usize, #[serde(default)] Vec<u32>),
 
     NewMemtable(usize),
 
     /// Compaction output. For each output SST, record the set of vLog files
     /// it references so the SST → vLog map is reconstructable from the
     /// manifest alone.
-    Compaction(CompactionTask, Vec<(usize, Vec<u32>)>),
+    Compaction(CompactionTask, #[serde(default)] Vec<(usize, Vec<u32>)>),
 
     /// vLog file lifecycle.
     NewVlogFile(u32),

--- a/rfcs/001-key-value-separation.md
+++ b/rfcs/001-key-value-separation.md
@@ -97,15 +97,38 @@ pub struct ValuePointer {
     pub size: u32,
 }
 
+/// Per-entry value-kind stored in SST block metadata alongside each key-value
+/// pair. This is the authoritative source of truth for distinguishing inline
+/// values from vLog pointers. A single-byte tag prefix in the value payload
+/// (see `VALUE_POINTER_TAG`) is also present as a fast-path sanity check, but
+/// the `KvKind` is what the reader trusts — it eliminates the collision risk
+/// where a user value whose first byte happens to be `0xFF` would otherwise be
+/// misclassified as a pointer.
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum KvKind {
+    /// The value is stored inline in the SST block.
+    Inline = 0,
+    /// The value is a 17-byte encoded `ValuePointer` that references the vLog.
+    ValuePointer = 1,
+}
+
+impl KvKind {
+    pub fn from_u8(v: u8) -> Option<Self> {
+        match v {
+            0 => Some(Self::Inline),
+            1 => Some(Self::ValuePointer),
+            _ => None,
+        }
+    }
+}
+
 /// Magic tag byte that prefixes every encoded `ValuePointer`.
 ///
-/// Without an explicit tag, any 16-byte inline value (UUID, hash, small blob,
-/// etc.) would be indistinguishable from an encoded pointer. The tag makes the
-/// encoding self-describing so `try_decode` can safely classify a value during
-/// compaction or GC analysis. `0xFF` is chosen because it is an extremely
-/// uncommon prefix for legitimate user payloads; a stronger guarantee can be
-/// obtained by also tracking the type via a per-entry meta flag in the SST
-/// (see `KvKind` in section 5).
+/// Serves as a fast-path sanity check: if the first byte of a candidate value
+/// is not `0xFF`, the value is definitely not a pointer. However the
+/// authoritative classification comes from `KvKind` stored in the SST block
+/// metadata, because a user value can legitimately start with `0xFF`.
 const VALUE_POINTER_TAG: u8 = 0xFF;
 
 impl ValuePointer {
@@ -119,27 +142,34 @@ impl ValuePointer {
         buf.put_u32(self.size);
     }
 
-    /// Decode from bytes. Panics if the buffer is malformed.
-    pub fn decode(mut buf: &[u8]) -> Self {
-        assert!(buf.len() >= Self::encoded_size(), "ValuePointer buffer too short");
+    /// Decode from bytes. Returns an error if the buffer is malformed.
+    pub fn decode(mut buf: &[u8]) -> Result<Self> {
+        if buf.len() < Self::encoded_size() {
+            return Err(anyhow!("ValuePointer buffer too short: {} < {}", buf.len(), Self::encoded_size()));
+        }
         let tag = buf.get_u8();
-        assert_eq!(tag, VALUE_POINTER_TAG, "ValuePointer tag mismatch");
-        Self {
+        if tag != VALUE_POINTER_TAG {
+            return Err(anyhow!("ValuePointer tag mismatch: expected 0x{:02X}, got 0x{:02X}", VALUE_POINTER_TAG, tag));
+        }
+        Ok(Self {
             file_id: buf.get_u32(),
             offset: buf.get_u64(),
             size: buf.get_u32(),
-        }
+        })
     }
 
     /// Try to decode from bytes. Returns `None` if the buffer is too short or
-    /// does not start with the `VALUE_POINTER_TAG` byte. This makes the
-    /// classification of "inline value" vs. "value pointer" unambiguous, so an
-    /// inline 16-byte UUID can never be mistaken for a pointer.
+    /// does not start with the `VALUE_POINTER_TAG` byte.
+    ///
+    /// Callers that have access to the SST block's `KvKind` metadata should
+    /// check that first (it is authoritative) and only use `try_decode` as a
+    /// fast-path filter. This avoids the edge-case collision where a user value
+    /// whose first byte is `0xFF` could be misclassified as a pointer.
     pub fn try_decode(buf: &[u8]) -> Option<Self> {
         if buf.len() < Self::encoded_size() || buf[0] != VALUE_POINTER_TAG {
             return None;
         }
-        Some(Self::decode(buf))
+        Self::decode(buf).ok()
     }
 
     /// Total encoded size: 17 bytes (1-byte tag + 4 + 8 + 4)
@@ -183,6 +213,7 @@ impl ValuePointer {
 const VLOG_MAGIC: u32 = 0x564C4F47; // "VLOG"
 
 /// Value log file header (first 16 bytes of each vLog file)
+#[repr(C)]
 #[derive(Clone, Debug)]
 pub struct VlogFileHeader {
     pub magic: u32,           // 4 bytes
@@ -319,30 +350,34 @@ impl SsTableBuilder {
 
         self.key_hashes.push(farmhash::fingerprint32(key.raw_ref()));
 
-        // NEW: Check if value should be separated
-        let value_to_store = if self.should_separate_value(value) {
+        // NEW: Check if value should be separated and annotate with KvKind
+        let (value_to_store, kind) = if self.should_separate_value(key, value) {
             let vptr = self.write_to_vlog(key, value);
             // Store the encoded pointer instead of the value
             self.vlog_buffer.clear();
             vptr.encode(&mut self.vlog_buffer);
-            &self.vlog_buffer[..ValuePointer::encoded_size()]
+            (&self.vlog_buffer[..ValuePointer::encoded_size()], KvKind::ValuePointer)
         } else {
             // During compaction, values may already be encoded ValuePointers.
-            // Track their vLog references to prevent premature GC.
-            if let Some(vptr) = ValuePointer::try_decode(value) {
-                self.referenced_vlogs.insert(vptr.file_id);
+            // Use KvKind metadata (authoritative) rather than try_decode alone.
+            if value.len() == ValuePointer::encoded_size() && value[0] == VALUE_POINTER_TAG {
+                if let Some(vptr) = ValuePointer::try_decode(value) {
+                    self.referenced_vlogs.insert(vptr.file_id);
+                }
             }
-            value
+            (value, KvKind::Inline)
         };
 
-        if self.builder.add(key, value_to_store) {
+        // Each block entry now carries (key, value, KvKind) so that the
+        // reader can classify the value without guessing from the payload.
+        if self.builder.add_with_kind(key, value_to_store, kind) {
             self.last_key.set_from_slice(key);
             return;
         }
 
         self.finish_block();
         self.first_key.set_from_slice(key);
-        assert!(self.builder.add(key, value_to_store));
+        assert!(self.builder.add_with_kind(key, value_to_store, kind));
         self.last_key.set_from_slice(key);
     }
 
@@ -353,9 +388,13 @@ impl SsTableBuilder {
         ptr
     }
 
-    fn should_separate_value(&self, value: &[u8]) -> bool {
+    fn should_separate_value(&self, key: KeySlice, value: &[u8]) -> bool {
         match &self.vlog_options {
-            Some(opts) if opts.enabled => value.len() >= opts.min_value_size,
+            Some(opts) if opts.enabled => {
+                // Keys stored in vLog must fit in the u16 key_len field
+                value.len() >= opts.min_value_size
+                    && key.raw_ref().len() <= u16::MAX as usize
+            }
             _ => false,
         }
     }
@@ -365,28 +404,51 @@ impl SsTableBuilder {
 ### 6. ValueLog Implementation
 
 ```rust
+/// Pending deletion entry: a vLog file that has been retired by GC but whose
+/// on-disk deletion is deferred until it is safe.
+pub struct PendingDeletion {
+    file_id: u32,
+    /// The engine timestamp / epoch at the moment GC retired this file.
+    obsolete_at_ts: u64,
+}
+
 /// Manages value log files for the storage engine.
 pub struct ValueLog {
     /// Path to the vLog directory
     path: PathBuf,
-    
+
     /// Currently active vLog file for writing
     active_writer: Mutex<ValueLogWriter>,
-    
+
     /// Read cache for vLog files (file_id -> Arc<ValueLogReader>)
     readers: moka::sync::Cache<u32, Arc<ValueLogReader>>,
-    
+
     /// Next vLog file ID
     next_file_id: AtomicU32,
-    
+
     /// Configuration options
     options: ValueSeparationOptions,
-    
-    /// Tracks which SSTs reference which vLog entries
-    /// Used for garbage collection
+
+    /// Tracks which SSTs reference which vLog entries.
     /// Populated during SST build: when an SST is finalized, the vLog file IDs
-    /// it references are registered via register_sst_references()
+    /// it references are registered via register_sst_references().
     sst_to_vlogs: RwLock<HashMap<usize, HashSet<u32>>>,
+
+    /// Monotonic clock / timestamp provider (shared with the LSM engine).
+    /// Used by `schedule_deletion` to stamp each retired file with the
+    /// current MVCC epoch so the deferred-reclamation pass can compare it
+    /// against the MVCC watermark.
+    lsm_clock: Arc<dyn Clock>,
+
+    /// vLog files that have been retired by GC but not yet unlinked.
+    /// Protected by a mutex; drained by `reclaim_pending_deletions`.
+    pending_deletions: Mutex<Vec<PendingDeletion>>,
+
+    /// Per-file open-reader reference count. Incremented when a
+    /// `ValueLogReader` is fetched from the cache; decremented on drop.
+    /// Used by `reclaim_pending_deletions` to ensure a file is not deleted
+    /// while an iterator or snapshot still holds an open handle.
+    reader_refcounts: RwLock<HashMap<u32, usize>>,
 }
 
 impl ValueLog {
@@ -432,17 +494,45 @@ impl ValueLog {
             .collect()
     }
 
-    /// Read a value using a ValuePointer.
+    /// Read a value using a ValuePointer. Returns only the value bytes
+    /// (the caller never needs to see the vLog header or key).
     pub fn read(&self, ptr: &ValuePointer) -> Result<Bytes> {
         let reader = self.get_reader(ptr.file_id)?;
-        reader.read_at(ptr.offset, ptr.size)
+        let entry = reader.read_entry(ptr.offset, ptr.size)?;
+        Ok(entry.value.freeze())
     }
 
     /// Get a cached reader for the specified vLog file.
     fn get_reader(&self, file_id: u32) -> Result<Arc<ValueLogReader>> {
-        self.readers.try_get_with(file_id, || {
-            ValueLogReader::open(self.path_of_file(file_id))
-        }).map_err(|e| anyhow!("Failed to open vlog {}: {}", file_id, e))
+        let reader = self.readers.try_get_with(file_id, || {
+            ValueLogReader::open(self.path_of_file(file_id)).map(Arc::new)
+        }).map_err(|e| anyhow!("Failed to open vlog {}: {}", file_id, e))?;
+        // Track open-reader reference count for safe deferred deletion.
+        *self.reader_refcounts.write().entry(file_id).or_insert(0) += 1;
+        Ok(reader)
+    }
+
+    /// Decrements the reference count for a vLog file reader.
+    /// Called when a `ValueLogReaderHandle` is dropped.
+    fn release_reader(&self, file_id: u32) {
+        let mut counts = self.reader_refcounts.write();
+        if let Some(count) = counts.get_mut(&file_id) {
+            *count = count.saturating_sub(1);
+            if *count == 0 {
+                counts.remove(&file_id);
+            }
+        }
+    }
+
+    /// Returns the current open-reader reference count for a vLog file.
+    /// Used by `reclaim_pending_deletions` to ensure a file is not deleted
+    /// while iterators or snapshots still hold an open handle.
+    pub fn reader_refcount(&self, file_id: u32) -> usize {
+        self.reader_refcounts
+            .read()
+            .get(&file_id)
+            .copied()
+            .unwrap_or(0)
     }
 
     /// Return the current configuration options.

--- a/rfcs/001-key-value-separation.md
+++ b/rfcs/001-key-value-separation.md
@@ -244,6 +244,11 @@ pub struct VlogFileHeader {
 /// keeps the C struct layout naturally 4-byte-aligned with no implicit padding
 /// between the declared fields. The trailing `_padding` brings the total to a
 /// flat 16 bytes and preserves the file's 8-byte alignment guarantee.
+///
+/// **Portability note:** `#[repr(C)]` guarantees field order and size but not
+/// endianness. All serialization code MUST use explicit little-endian encoding
+/// (e.g., `u32::to_le_bytes()`) rather than `std::mem::transmute`, so the
+/// on-disk format is architecture-independent.
 #[repr(C)]
 pub struct VlogEntryHeader {
     pub crc32: u32,           // CRC32 of the rest of the header + key + value (4 bytes)
@@ -400,6 +405,11 @@ impl SsTableBuilder {
 
         self.key_hashes.push(farmhash::fingerprint32(key.raw_ref()));
 
+        // Local buffer for encoded ValuePointer — declared here so its slice
+        // reference can be used in the `value_to_store` binding below without
+        // borrow checker conflicts with self.finish_block().
+        let mut local_buf = Vec::new();
+
         // Determine value-to-store and KvKind.
         //
         // During compaction the caller passes `input_kind` from the source SST's
@@ -418,12 +428,11 @@ impl SsTableBuilder {
         } else if self.should_separate_value(key, value) {
             let vptr = self.write_to_vlog(key, value);
             // Encode into a local Vec — avoids borrow checker conflict with
-            // self.finish_block() below (self.vlog_buffer would hold &mut self).
-            // The buffer is small (17 bytes) and only allocated on the separation
-            // path, so the cost is negligible.
-            let mut local_buf = Vec::with_capacity(ValuePointer::encoded_size());
+            // self.finish_block() below. The buffer is small (17 bytes) and
+            // only allocated on the separation path, so the cost is negligible.
+            local_buf.reserve(ValuePointer::encoded_size());
             vptr.encode(&mut local_buf);
-            return self.add_with_kind(key, &local_buf, Some(KvKind::ValuePointer));
+            (local_buf.as_slice(), KvKind::ValuePointer)
         } else {
             (value, KvKind::Inline)
         };
@@ -1262,6 +1271,11 @@ pub enum ManifestRecord {
     /// Compaction output. For each output SST, record the set of vLog files
     /// it references so the SST → vLog map is reconstructable from the
     /// manifest alone.
+    // NOTE: serde(default) on a tuple variant field works with bincode but may
+    // not work with all serde formats (e.g., serde_json requires the field to
+    // be optional or have a default for each element). Since the manifest uses
+    // bincode this is safe, but if the format ever changes this line must be
+    // revisited. An alternative is to introduce a CompactionV2 variant.
     Compaction(CompactionTask, #[serde(default)] Vec<(usize, Vec<u32>)>),
 
     /// vLog file lifecycle.

--- a/rfcs/001-key-value-separation.md
+++ b/rfcs/001-key-value-separation.md
@@ -607,7 +607,14 @@ impl ValueLog {
 
         let mut writer = self.active_writer.lock();
 
-        // Rotate to new file if current is full
+        // Rotate to new file if current is full.
+        // NOTE: rotate_vlog_file must NOT write to the manifest directly,
+        // because ValueLog::write does not hold the state_lock and acquiring
+        // it here would create an AB-BA deadlock (active_writer → state_lock
+        // vs. state_lock → active_writer in flush/compaction paths). Instead,
+        // rotation just creates the new file; the manifest NewVlogFile record
+        // is written by the caller (flush or compaction) which already holds
+        // the state_lock.
         if writer.size() >= self.options.max_vlog_file_size {
             self.rotate_vlog_file(&mut writer)?;
         }
@@ -1063,11 +1070,16 @@ impl CompactionController {
         self.gc_pool.spawn(move || {
             let gc = GarbageCollector::new(vlog.clone(), lsm, vlog.options().gc_threshold_ratio);
             for file_id in affected_vlogs {
+                // Skip if another GC task is already processing this file.
+                if !gc.try_acquire_gc_lock(file_id) {
+                    continue;
+                }
                 if let Ok(analysis) = gc.analyze_file(file_id) {
                     if analysis.stale_ratio >= vlog.options().gc_threshold_ratio {
                         let _ = gc.compact_file(&analysis);
                     }
                 }
+                gc.release_gc_lock(file_id);
             }
         });
 
@@ -1086,11 +1098,20 @@ impl CompactionController {
         }
 
         // Clean up vLog references for input SSTs that are being replaced.
-        // Without this, get_ssts_referencing() would still return stale SST IDs,
-        // preventing reclaim_pending_deletions() from ever unlinking retired vLogs.
-        for sst_id in input_ssts {
-            vlog.unregister_sst_references(*sst_id);
-        }
+        // DEFERRED: Do NOT unregister immediately here. Active snapshots or
+        // long-running iterators may still hold Arc<SsTable> references to
+        // these input SSTs. If we unregister now and GC runs, it could see
+        // get_ssts_referencing().is_empty() and delete the vLog file while
+        // those iterators still need it.
+        //
+        // Instead, defer unregistration to SsTable::drop (or a drop token/
+        // callback). This guarantees a vLog file is never physically deleted
+        // while any snapshot or iterator holds a reference to an SST that
+        // points to it.
+        //
+        // for sst_id in input_ssts {
+        //     vlog.unregister_sst_references(*sst_id);
+        // }
 
         Ok(())
     }

--- a/rfcs/001-key-value-separation.md
+++ b/rfcs/001-key-value-separation.md
@@ -245,11 +245,13 @@ pub struct VlogFileHeader {
 /// between the declared fields. The trailing `_padding` brings the total to a
 /// flat 16 bytes and preserves the file's 8-byte alignment guarantee.
 ///
-/// **Portability note:** `#[repr(C)]` guarantees field order and size but not
-/// endianness. All serialization code MUST use explicit little-endian encoding
-/// (e.g., `u32::to_le_bytes()`) rather than `std::mem::transmute`, so the
-/// on-disk format is architecture-independent.
-#[repr(C)]
+/// **Serialization note:** Do NOT cast raw byte buffers to `&VlogEntryHeader`
+/// — vLog entries are read from arbitrary file offsets where 4-byte alignment
+/// is not guaranteed, making pointer casts undefined behavior.  Instead,
+/// serialize/deserialize each field individually using explicit little-endian
+/// encoding (e.g., `bytes::Buf::get_u32_le()` / `bytes::BufMut::put_u32_le()`).
+/// This also makes `#[repr(C)]` and `std::mem::size_of` unnecessary; the
+/// header is always exactly 16 bytes by construction.
 pub struct VlogEntryHeader {
     pub crc32: u32,           // CRC32 of the rest of the header + key + value (4 bytes)
     pub value_len: u32,       // Value length (max 4GB) (4 bytes)
@@ -258,7 +260,7 @@ pub struct VlogEntryHeader {
     pub _padding: [u8; 4],    // Reserved / padding to a 16-byte total
 }
 
-const HEADER_SIZE: usize = std::mem::size_of::<VlogEntryHeader>(); // 16
+const HEADER_SIZE: usize = 16; // VlogEntryHeader is always 16 bytes
 const ALIGNMENT: usize = 8;
 ```
 
@@ -282,25 +284,21 @@ impl ValueLogBuilder {
     /// the entry and advance to the next one without re-reading the header.
     pub fn add(&mut self, key: &[u8], value: &[u8]) -> ValuePointer {
         let offset = self.writer.offset();
-        let payload = HEADER_SIZE + key.len() + value.len();
-        let padded = (payload + ALIGNMENT - 1) & !(ALIGNMENT - 1);
-        let pad = padded - payload;
 
         // Validate BEFORE writing to avoid corrupting the vLog with an oversized entry.
+        let total = self.writer.append(key, value);
         assert!(
-            padded <= u32::MAX as usize,
+            total <= u32::MAX as usize,
             "vLog entry size {} exceeds u32 capacity — increase max_value_size or reduce key/value size",
-            padded
+            total
         );
-
-        self.writer.append_with_pad(key, value, pad);
 
         debug_assert_eq!(self.writer.offset() % ALIGNMENT as u64, 0);
 
         ValuePointer {
             file_id: self.file_id,
             offset,
-            size: padded as u32,
+            size: total as u32,
         }
     }
 }
@@ -856,11 +854,12 @@ impl GarbageCollector {
     /// entry becomes orphaned (unreferenced by any SST).
     ///
     /// **Orphan reclamation**: entries written to the new vLog before a failed
-    /// CAS are unreferenced but occupy space. Two strategies:
-    /// (a) Track a "committed watermark" per vLog file — entries above the
-    ///     watermark are treated as dead by the next GC pass.
-    /// (b) Use a tombstone marker: on CAS failure, write a zero-length tombstone
-    ///     entry so the reader knows to skip it and the GC can reclaim the space.
+    /// CAS are unreferenced but occupy space. No special watermark or tombstone
+    /// tracking is needed — the LSM tree is the authoritative source of truth
+    /// for liveness.  During the next GC pass of the new vLog file,
+    /// `check_liveness` will return `false` for any orphaned entries (they are
+    /// not pointed to by any SST), so they are naturally reclaimed by the
+    /// standard GC mechanism.
     pub fn compact_file(&self, analysis: &GcAnalysis) -> Result<()> {
         if analysis.stale_ratio < self.threshold {
             return Ok(());
@@ -1010,11 +1009,16 @@ impl CompactionController {
             }
         });
 
-        // Register vLog references for output SSTs.
+        // Register vLog references for output SSTs BEFORE removing input refs.
         // SsTableBuilder is a low-level component without access to ValueLog.
         // Registration is handled by the storage engine (LsmStorageInner) when
         // it receives the finalized SST: the builder exposes its referenced_vlogs
         // set via a getter, and the engine calls vlog.register_sst_references().
+        //
+        // CRITICAL: output registration must precede input unregistration.
+        // Otherwise reclaim_pending_deletions() can observe an empty
+        // get_ssts_referencing(file_id) for a still-live vLog file and unlink
+        // it, causing read failures or data loss.
         for sst_id in output_ssts {
             // Engine registers: builder.get_referenced_vlogs() → vlog.register_sst_references(sst_id, vlogs)
         }
@@ -1261,22 +1265,26 @@ O(total SST count) once vLog adoption grows.
 ```rust
 #[derive(Serialize, Deserialize)]
 pub enum ManifestRecord {
-    /// Flush of a memtable to L0. Carries the vLog files this new SST
-    /// references (empty if the SST has no separated values).
-    /// `#[serde(default)]` ensures old manifests without vLog data still parse.
-    Flush(usize, #[serde(default)] Vec<u32>),
+    /// Flush of a memtable to L0. Original variant kept for backward compat.
+    Flush(usize),
+
+    /// Flush with vLog references. Named fields so serde_json can deserialize
+    /// even when the `vlogs` key is absent from old manifests.
+    FlushV2 { sst_id: usize, #[serde(default)] vlogs: Vec<u32> },
 
     NewMemtable(usize),
 
     /// Compaction output. For each output SST, record the set of vLog files
     /// it references so the SST → vLog map is reconstructable from the
     /// manifest alone.
-    // NOTE: serde(default) on a tuple variant field works with bincode but may
-    // not work with all serde formats (e.g., serde_json requires the field to
-    // be optional or have a default for each element). Since the manifest uses
-    // bincode this is safe, but if the format ever changes this line must be
-    // revisited. An alternative is to introduce a CompactionV2 variant.
-    Compaction(CompactionTask, #[serde(default)] Vec<(usize, Vec<u32>)>),
+    // NOTE: The manifest uses serde_json, and #[serde(default)] on a tuple
+    // variant field does NOT work with serde_json (it cannot deserialize a
+    // single-element JSON array into a two-element Rust tuple). To preserve
+    // backward compatibility with existing manifests, keep the original
+    // variants unchanged and introduce new V2 variants with named fields.
+    // The recovery code should accept both old and new variants.
+    Compaction(CompactionTask, Vec<usize>),
+    CompactionV2 { task: CompactionTask, output_ssts: Vec<(usize, Vec<u32>)> },
 
     /// vLog file lifecycle.
     NewVlogFile(u32),
@@ -1284,18 +1292,20 @@ pub enum ManifestRecord {
 }
 ```
 
-Recovery walks the manifest as before; for every `Flush` / `Compaction` record
-it calls `register_sst_references(sst_id, vlog_ids)` to populate **both**
-`sst_to_vlogs` and `vlog_to_ssts` indexes. SSTable footers still embed the
-vLog reference list as a redundant copy, used by `fsck`-style consistency
-checks and by older snapshots whose manifest record predates this format.
+Recovery walks the manifest as before; for every `Flush` / `FlushV2` /
+`Compaction` / `CompactionV2` record it calls `register_sst_references(sst_id,
+vlog_ids)` to populate **both** `sst_to_vlogs` and `vlog_to_ssts` indexes.
+Old `Flush(usize)` and `Compaction(usize, Vec<usize>)` records are treated as
+having an empty vLog set. SSTable footers still embed the vLog reference list
+as a redundant copy, used by `fsck`-style consistency checks and by older
+snapshots whose manifest record predates this format.
 
 ## Crash Recovery
 
 The WAL stores full values for user writes, so crash recovery for the normal write path does not depend on vLog pointers at all. Recovery proceeds in three phases:
 
 1. **WAL replay**: rebuilds the memtable with full values — identical to a non-separated engine. No vLog validation needed for user writes.
-2. **Manifest replay**: for every `Flush` / `Compaction` record, call `register_sst_references(sst_id, vlog_ids)` to populate both `sst_to_vlogs` and `vlog_to_ssts` indexes.
+2. **Manifest replay**: for every `Flush` / `FlushV2` / `Compaction` / `CompactionV2` record, call `register_sst_references(sst_id, vlog_ids)` to populate both `sst_to_vlogs` and `vlog_to_ssts` indexes.
 3. **Orphan vLog cleanup**: scan the data directory for `.vlog` files. Any file not referenced by a `NewVlogFile` manifest record, by any SST's vLog reference list, **or by the WAL-recovered memtable** is orphaned and deleted. The memtable check is critical: GC's `compare_and_set_with_kind` writes `ValuePointer` entries to the memtable (and WAL), so after WAL replay these pointers must remain valid. Deleting a vLog file reachable only through the recovered memtable would cause read failures.
 
 **Flush-time crash safety**: vLog writes are fsynced (batch, once per flush) before the SST is written to disk. If a crash occurs:

--- a/rfcs/001-key-value-separation.md
+++ b/rfcs/001-key-value-separation.md
@@ -169,7 +169,14 @@ impl ValuePointer {
         if buf.len() < Self::encoded_size() || buf[0] != VALUE_POINTER_TAG {
             return None;
         }
-        Self::decode(buf).ok()
+        // Inline field decoding to avoid redundant length/tag checks
+        // and anyhow error construction in the hot path.
+        let mut b = &buf[1..];
+        Some(Self {
+            file_id: b.get_u32(),
+            offset: b.get_u64(),
+            size: b.get_u32(),
+        })
     }
 
     /// Total encoded size: 17 bytes (1-byte tag + 4 + 8 + 4)
@@ -419,6 +426,15 @@ pub struct PendingDeletion {
     obsolete_at_ts: u64,
 }
 
+/// Bidirectional SST ↔ vLog reference tracking.
+/// Both maps under a single lock to prevent deadlocks.
+pub struct VlogReferences {
+    /// SST ID → set of vLog files it references
+    sst_to_vlogs: HashMap<usize, HashSet<u32>>,
+    /// vLog file ID → set of SSTs referencing it (reverse index)
+    vlog_to_ssts: HashMap<u32, HashSet<usize>>,
+}
+
 /// RAII guard for a cached vLog reader. Automatically decrements the
 /// ValueLog's reader_refcount when dropped, preventing retired vLog files
 /// from being unlinked while an iterator or snapshot still reads them.
@@ -456,14 +472,10 @@ pub struct ValueLog {
     /// Configuration options
     options: ValueSeparationOptions,
 
-    /// Tracks which SSTs reference which vLog entries.
-    /// Populated during SST build: when an SST is finalized, the vLog file IDs
-    /// it references are registered via register_sst_references().
-    sst_to_vlogs: RwLock<HashMap<usize, HashSet<u32>>>,
-
-    /// Reverse index: vLog file ID → set of SSTs referencing it.
-    /// Kept in sync with sst_to_vlogs for O(1) lookups during GC.
-    vlog_to_ssts: RwLock<HashMap<u32, HashSet<usize>>>,
+    /// SST ↔ vLog bidirectional reference tracking.
+    /// Both maps live under a single lock to prevent deadlocks from
+    /// inconsistent acquisition order.
+    vlog_refs: RwLock<VlogReferences>,
 
     /// Monotonic clock / timestamp provider (shared with the LSM engine).
     /// Used by `schedule_deletion` to stamp each retired file with the
@@ -497,40 +509,41 @@ impl ValueLog {
     }
 
     /// Register SST -> vLog references when an SST is finalized.
-    /// Updates both forward (sst_to_vlogs) and reverse (vlog_to_ssts) indexes.
+    /// Updates both forward and reverse indexes atomically under one lock.
     pub fn register_sst_references(&self, sst_id: usize, vlog_ids: HashSet<u32>) {
+        let mut refs = self.vlog_refs.write();
         for vlog_id in &vlog_ids {
-            self.vlog_to_ssts.write().entry(*vlog_id).or_default().insert(sst_id);
+            refs.vlog_to_ssts.entry(*vlog_id).or_default().insert(sst_id);
         }
-        self.sst_to_vlogs.write().insert(sst_id, vlog_ids);
+        refs.sst_to_vlogs.insert(sst_id, vlog_ids);
     }
 
     /// Get all vLog files referenced by a given SST.
     pub fn get_sst_references(&self, sst_id: usize) -> Option<HashSet<u32>> {
-        let mapping = self.sst_to_vlogs.read();
-        mapping.get(&sst_id).cloned()
+        self.vlog_refs.read().sst_to_vlogs.get(&sst_id).cloned()
     }
 
     /// Get all SSTs that reference a given vLog file.
     /// Uses the reverse index for O(1) lookup.
     pub fn get_ssts_referencing(&self, vlog_id: u32) -> Vec<usize> {
-        self.vlog_to_ssts
+        self.vlog_refs
             .read()
+            .vlog_to_ssts
             .get(&vlog_id)
             .map(|ssts| ssts.iter().copied().collect())
             .unwrap_or_default()
     }
 
     /// Remove all vLog references for a deleted SST.
-    /// Updates both forward and reverse indexes.
+    /// Updates both indexes atomically under one lock.
     pub fn unregister_sst_references(&self, sst_id: usize) {
-        if let Some(vlog_ids) = self.sst_to_vlogs.write().remove(&sst_id) {
-            let mut reverse = self.vlog_to_ssts.write();
+        let mut refs = self.vlog_refs.write();
+        if let Some(vlog_ids) = refs.sst_to_vlogs.remove(&sst_id) {
             for vlog_id in vlog_ids {
-                if let Some(ssts) = reverse.get_mut(&vlog_id) {
+                if let Some(ssts) = refs.vlog_to_ssts.get_mut(&vlog_id) {
                     ssts.remove(&sst_id);
                     if ssts.is_empty() {
-                        reverse.remove(&vlog_id);
+                        refs.vlog_to_ssts.remove(&vlog_id);
                     }
                 }
             }
@@ -677,10 +690,17 @@ pub struct VlogEntry {
 }
 
 /// Analysis result for a single vLog file.
+/// Lightweight reference to a live vLog entry — stores only the pointer
+/// and key (not the value) to avoid holding large values in memory during analysis.
+pub struct LiveEntryRef {
+    pub ptr: ValuePointer,
+    pub key: Vec<u8>,
+}
+
 pub struct GcAnalysis {
     pub file_id: u32,
     pub stale_ratio: f64,
-    pub live_entries: Vec<VlogEntry>,
+    pub live_entries: Vec<LiveEntryRef>,
     pub dead_bytes: usize,
 }
 
@@ -710,11 +730,13 @@ impl GarbageCollector {
         let mut live_bytes = 0;
 
         for entry in reader.iter() {
+            let entry_size = entry.size;
             if self.is_entry_live(&entry)? {
-                live_entries.push(entry);
-                live_bytes += entry.size;
+                // Store only key + pointer, not the (potentially large) value.
+                live_entries.push(LiveEntryRef { ptr: entry.ptr, key: entry.key });
+                live_bytes += entry_size;
             } else {
-                dead_bytes += entry.size;
+                dead_bytes += entry_size;
             }
         }
 
@@ -749,9 +771,11 @@ impl GarbageCollector {
         let new_file_id = self.vlog.next_file_id();
         let mut writer = ValueLogWriter::create(self.vlog.path_of_file(new_file_id))?;
 
-        // Rewrite live entries and update LSM index
-        for entry in &analysis.live_entries {
-            let new_ptr = writer.append(&entry.key, &entry.value)?;
+        // Rewrite live entries and update LSM index.
+        // Values are re-read from the vLog (not held in memory from analysis).
+        for entry_ref in &analysis.live_entries {
+            let value = self.vlog.read(&entry_ref.ptr, &entry_ref.key)?;
+            let new_ptr = writer.append(&entry_ref.key, &value)?;
             let mut buf = Vec::with_capacity(ValuePointer::encoded_size());
             new_ptr.encode(&mut buf);
 
@@ -762,11 +786,13 @@ impl GarbageCollector {
             // GC writes with the write batch lock and re-check `is_entry_live`
             // inside the critical section.
             let mut expected_buf = Vec::with_capacity(ValuePointer::encoded_size());
-            entry.ptr.encode(&mut expected_buf);
-            if !self.lsm.compare_and_set(
-                &entry.key,
-                &expected_buf,
-                &buf,
+            entry_ref.ptr.encode(&mut expected_buf);
+            // Kind-aware CAS: ensures we don't overwrite an inline user value
+            // that happens to be byte-identical to the old pointer encoding.
+            if !self.lsm.compare_and_set_with_kind(
+                &entry_ref.key,
+                &expected_buf, KvKind::ValuePointer,
+                &buf, KvKind::ValuePointer,
             )? {
                 continue; // A concurrent user write changed the value — skip this entry
             }
@@ -996,6 +1022,13 @@ impl MiniLsm {
     /// Returns true if the swap succeeded, false if the value changed.
     /// Used by GC to avoid overwriting fresher user writes during re-insertion.
     pub fn compare_and_set(&self, key: &[u8], old: &[u8], new: &[u8]) -> Result<bool>;
+
+    /// Kind-aware CAS: checks both value bytes AND KvKind.
+    /// Prevents GC from overwriting an inline user value that happens to be
+    /// byte-identical to an encoded ValuePointer (17 bytes starting with 0xFF).
+    pub fn compare_and_set_with_kind(
+        &self, key: &[u8], old: &[u8], old_kind: KvKind, new: &[u8], new_kind: KvKind,
+    ) -> Result<bool>;
 }
 ```
 
@@ -1116,10 +1149,10 @@ pub enum ManifestRecord {
 ```
 
 Recovery walks the manifest as before; for every `Flush` / `Compaction` record
-it inserts the carried `(sst_id, vlog_ids)` pairs into `sst_to_vlogs`. SSTable
-footers still embed the vLog reference list as a redundant copy, used by
-`fsck`-style consistency checks and by older snapshots whose manifest record
-predates this format.
+it calls `register_sst_references(sst_id, vlog_ids)` to populate **both**
+`sst_to_vlogs` and `vlog_to_ssts` indexes. SSTable footers still embed the
+vLog reference list as a redundant copy, used by `fsck`-style consistency
+checks and by older snapshots whose manifest record predates this format.
 
 ## Crash Recovery
 

--- a/rfcs/001-key-value-separation.md
+++ b/rfcs/001-key-value-separation.md
@@ -381,7 +381,19 @@ impl SsTableBuilder {
     /// When `input_kind` is `None` (flush path), this method writes large values
     /// to the vLog and stores only the `ValuePointer` in the SST. The vLog is
     /// fsynced before the SST entry is written, so every pointer is durable.
-    pub fn add(&mut self, key: KeySlice, value: &[u8], input_kind: Option<KvKind>) {
+    /// Backward-compatible wrapper: defaults to `input_kind = None` (flush path).
+    pub fn add(&mut self, key: KeySlice, value: &[u8]) {
+        self.add_with_kind(key, value, None);
+    }
+
+    /// Add a key-value pair to the builder with an explicit KvKind.
+    /// `input_kind`: pass `Some(KvKind)` during compaction (from source SST metadata),
+    /// or `None` for new writes (memtable flush) — the builder decides automatically.
+    ///
+    /// When `input_kind` is `None` (flush path), this method writes large values
+    /// to the vLog and stores only the `ValuePointer` in the SST. The vLog is
+    /// fsynced before the SST file is written, so every pointer is durable.
+    pub fn add_with_kind(&mut self, key: KeySlice, value: &[u8], input_kind: Option<KvKind>) {
         if self.first_key.is_empty() {
             self.first_key.set_from_slice(key);
         }
@@ -628,8 +640,10 @@ impl ValueLog {
         }).map_err(|e| anyhow!("Failed to open vlog {}: {}", file_id, e))?;
         // Get or create per-file atomic counter. Read lock first to avoid
         // contention on the common path (counter already exists).
-        let counter = if let Some(c) = self.reader_refcounts.read().get(&file_id) {
-            c.clone()
+        // Block expression drops the read guard before entering the else branch,
+        // preventing deadlock when upgrading to a write lock.
+        let counter = if let Some(c) = { self.reader_refcounts.read().get(&file_id).cloned() } {
+            c
         } else {
             self.reader_refcounts
                 .write()
@@ -637,7 +651,7 @@ impl ValueLog {
                 .or_insert_with(|| Arc::new(AtomicUsize::new(0)))
                 .clone()
         };
-        counter.fetch_add(1, Ordering::Relaxed);
+        counter.fetch_add(1, Ordering::Acquire);
         Ok(ValueLogReaderHandle { reader, vlog: self.clone(), file_id, counter })
     }
 
@@ -647,7 +661,10 @@ impl ValueLog {
     /// on the hot path. Stale entries are cleaned up periodically by
     /// `cleanup_stale_counters` or left in place (they are small).
     fn release_reader(&self, _file_id: u32, counter: &AtomicUsize) {
-        counter.fetch_sub(1, Ordering::Relaxed);
+        // Release ordering ensures all prior reads from the vLog file complete
+        // before the count is decremented. This prevents another thread from
+        // seeing count == 0 and deleting the file while reads are still in flight.
+        counter.fetch_sub(1, Ordering::Release);
     }
 
     /// Returns the current open-reader reference count for a vLog file.
@@ -657,7 +674,7 @@ impl ValueLog {
         self.reader_refcounts
             .read()
             .get(&file_id)
-            .map(|c| c.load(Ordering::Relaxed))
+            .map(|c| c.load(Ordering::Acquire))
             .unwrap_or(0)
     }
 
@@ -1257,17 +1274,20 @@ checks and by older snapshots whose manifest record predates this format.
 
 ## Crash Recovery
 
-The WAL stores full values, so crash recovery does not depend on vLog pointers at all. Recovery proceeds in two phases:
+The WAL stores full values for user writes, so crash recovery for the normal write path does not depend on vLog pointers at all. Recovery proceeds in three phases:
 
-1. **WAL replay**: rebuilds the memtable with full values — identical to a non-separated engine. No vLog validation needed.
+1. **WAL replay**: rebuilds the memtable with full values — identical to a non-separated engine. No vLog validation needed for user writes.
 2. **Manifest replay**: for every `Flush` / `Compaction` record, call `register_sst_references(sst_id, vlog_ids)` to populate both `sst_to_vlogs` and `vlog_to_ssts` indexes.
+3. **Orphan vLog cleanup**: scan the data directory for `.vlog` files. Any file not referenced by a `NewVlogFile` manifest record, by any SST's vLog reference list, **or by the WAL-recovered memtable** is orphaned and deleted. The memtable check is critical: GC's `compare_and_set_with_kind` writes `ValuePointer` entries to the memtable (and WAL), so after WAL replay these pointers must remain valid. Deleting a vLog file reachable only through the recovered memtable would cause read failures.
 
 **Flush-time crash safety**: vLog writes are fsynced (batch, once per flush) before the SST is written to disk. If a crash occurs:
 - **Before SST is committed to manifest**: the flush is incomplete — the memtable (rebuilt from WAL) still contains the full values. The partially written vLog and SST files are orphaned.
 - **After SST is committed to manifest**: all vLog pointers in the SST are guaranteed valid (vLog was fsynced first).
 - **Partial vLog write**: detected by CRC32 mismatch and skipped during reads.
 
-**Orphan cleanup on startup**: after WAL and manifest replay, the engine scans the data directory for `.vlog` files. Any file not referenced by a `NewVlogFile` manifest record (or by an SST's vLog reference list) is orphaned and deleted. This handles vLog files from crashed flushes that were never committed to the manifest.
+**GC crash safety**: GC's `compact_file` fsyncs the new vLog BEFORE performing any CAS operations (Phase 1 → Phase 2 ordering). On crash:
+- **Before CAS is flushed to SST**: WAL replay restores the old ValuePointer (pre-CAS state). The new vLog file is orphaned but harmless — it will be cleaned up on the next GC pass or startup orphan sweep.
+- **After CAS is flushed to SST**: the new ValuePointer is durable in the SST. The new vLog file is referenced by the SST and will not be deleted.
 
 ### WAL Interaction
 

--- a/rfcs/001-key-value-separation.md
+++ b/rfcs/001-key-value-separation.md
@@ -163,7 +163,7 @@ pub struct VlogFileHeader {
 #[repr(C)]
 pub struct VlogEntryHeader {
     pub crc32: u32,           // CRC32 of key + value (4 bytes)
-    pub key_len: u16,         // Key length (max 64KB) (2 bytes)
+    pub key_len: u16,         // Key length (max 64KB). Large keys must be stored inline. (2 bytes)
     pub value_len: u32,       // Value length (max 4GB) (4 bytes)
     pub flags: u16,           // Flags (tombstone, etc.) (2 bytes)
     pub _padding: [u8; 4],    // Padding to 16 bytes for alignment
@@ -172,6 +172,31 @@ pub struct VlogEntryHeader {
 const HEADER_SIZE: usize = std::mem::size_of::<VlogEntryHeader>();
 const TRAILER_SIZE: usize = 4; // CRC32 checksum
 const ALIGNMENT: usize = 8;
+```
+
+### 2.5 ValueLogBuilder
+
+The `ValueLogBuilder` constructs vLog entries during SSTable building. It is owned by `SsTableBuilder` and writes sequentially to the current vLog file.
+
+```rust
+/// Builder for constructing vLog entries during SST construction.
+pub struct ValueLogBuilder {
+    writer: ValueLogWriter,
+    file_id: u32,
+}
+
+impl ValueLogBuilder {
+    /// Add a key-value pair to the vLog. Returns a ValuePointer.
+    pub fn add(&mut self, key: &[u8], value: &[u8]) -> ValuePointer {
+        let offset = self.writer.offset();
+        self.writer.append(key, value);
+        ValuePointer {
+            file_id: self.file_id,
+            offset,
+            size: (key.len() + value.len() + HEADER_SIZE + TRAILER_SIZE) as u32,
+        }
+    }
+}
 ```
 
 ### 3. ValueLog Module Structure
@@ -235,16 +260,11 @@ pub struct SsTableBuilder {
     // NEW: Value log components
     vlog_options: Option<ValueSeparationOptions>,
     vlog_builder: Option<ValueLogBuilder>,
-    current_vlog_id: u32,
-    vlog_entries: Vec<(ValuePointer, Bytes)>, // Pending entries
+    vlog_buffer: Vec<u8>,
+    referenced_vlogs: HashSet<u32>,
 }
 
 impl SsTableBuilder {
-    /// Tracks which vLog files are referenced by the SST being built.
-    /// Populated during add() when values are separated to vLog.
-    /// This is used to register the SST -> vLog mapping when the SST is finalized.
-    referenced_vlogs: HashSet<u32>,
-
     pub fn add(&mut self, key: KeySlice, value: &[u8]) {
         if self.first_key.is_empty() {
             self.first_key.set_from_slice(key);
@@ -256,7 +276,6 @@ impl SsTableBuilder {
         let value_to_store = if self.should_separate_value(value) {
             let vptr = self.write_to_vlog(key, value);
             // Store the encoded pointer instead of the value
-            // Clear buffer first to avoid accumulating encoded pointers
             self.vlog_buffer.clear();
             vptr.encode(&mut self.vlog_buffer);
             &self.vlog_buffer[..ValuePointer::encoded_size()]
@@ -272,6 +291,13 @@ impl SsTableBuilder {
         self.finish_block();
         assert!(self.builder.add(key, value_to_store));
         self.last_key.set_from_slice(key);
+    }
+
+    /// Write a key-value pair to the active vLog builder and return a pointer.
+    fn write_to_vlog(&mut self, key: KeySlice, value: &[u8]) -> ValuePointer {
+        let ptr = self.vlog_builder.as_mut().unwrap().add(key.raw_ref(), value);
+        self.referenced_vlogs.insert(ptr.file_id);
+        ptr
     }
 
     fn should_separate_value(&self, value: &[u8]) -> bool {
@@ -365,6 +391,29 @@ impl ValueLog {
             ValueLogReader::open(self.path_of_file(file_id))
         }).map_err(|e| anyhow!("Failed to open vlog {}: {}", file_id, e))
     }
+
+    /// Return the current configuration options.
+    pub fn options(&self) -> &ValueSeparationOptions {
+        &self.options
+    }
+
+    /// Allocate and return the next vLog file ID.
+    pub fn next_file_id(&self) -> u32 {
+        self.next_file_id.fetch_add(1, std::sync::atomic::Ordering::SeqCst)
+    }
+
+    /// Return the filesystem path for a given vLog file ID.
+    fn path_of_file(&self, file_id: u32) -> PathBuf {
+        self.path.join(format!("{:05}.vlog", file_id))
+    }
+
+    /// Remove a vLog file from disk and invalidate the cache entry.
+    pub fn remove_file(&self, file_id: u32) -> Result<()> {
+        let path = self.path_of_file(file_id);
+        std::fs::remove_file(&path)?;
+        self.readers.invalidate(&file_id);
+        Ok(())
+    }
 }
 ```
 
@@ -372,11 +421,35 @@ impl ValueLog {
 
 Garbage collection is triggered during compaction when the ratio of stale data exceeds a threshold.
 
+**Important design choice**: Instead of rewriting SSTs to update value pointers (which would add massive write amplification and break SST immutability), we use the standard WiscKey approach:
+
+1. Scan the target vLog file and identify live entries
+2. Rewrite live entries to a new vLog file
+3. Re-insert each live key with its new `ValuePointer` into the LSM tree via the normal write path
+4. Old SSTs still contain stale pointers, but they are shadowed by the newer entries in the memtable and upper LSM levels
+5. Eventually, normal compaction removes old SSTs containing stale pointers
+
 ```rust
+/// A single entry read from a vLog file.
+pub struct VlogEntry {
+    pub ptr: ValuePointer,
+    pub key: Vec<u8>,
+    pub value: Vec<u8>,
+    pub size: usize,
+}
+
+/// Analysis result for a single vLog file.
+pub struct GcAnalysis {
+    pub file_id: u32,
+    pub stale_ratio: f64,
+    pub live_entries: Vec<VlogEntry>,
+    pub dead_bytes: usize,
+}
+
 /// Garbage collector for reclaiming space in value logs.
 pub struct GarbageCollector {
     vlog: Arc<ValueLog>,
-    lsm: Arc<MiniLsm>,  // Reference to LSM tree for liveness checks
+    lsm: Arc<MiniLsm>,
     threshold: f64,
 }
 
@@ -387,7 +460,11 @@ impl GarbageCollector {
     }
 
     /// Analyze a vLog file and determine which entries are still live.
-    /// Returns the ratio of live data.
+    /// Returns the ratio of stale (dead) data.
+    ///
+    /// Performance note: This performs an LSM `get()` for every entry in the vLog file.
+    /// For large vLog files this can be expensive. Consider scheduling GC during
+    /// low-traffic periods or processing files incrementally.
     pub fn analyze_file(&self, file_id: u32) -> Result<GcAnalysis> {
         let reader = self.vlog.get_reader(file_id)?;
         let mut live_entries = Vec::new();
@@ -396,7 +473,7 @@ impl GarbageCollector {
 
         for entry in reader.iter() {
             if self.is_entry_live(&entry)? {
-                live_entries.push(entry.ptr);
+                live_entries.push(entry);
                 live_bytes += entry.size;
             } else {
                 dead_bytes += entry.size;
@@ -404,84 +481,53 @@ impl GarbageCollector {
         }
 
         let total = live_bytes + dead_bytes;
-        let live_ratio = if total > 0 { live_bytes as f64 / total as f64 } else { 1.0 };
+        let stale_ratio = if total > 0 { dead_bytes as f64 / total as f64 } else { 0.0 };
 
         Ok(GcAnalysis {
             file_id,
-            live_ratio,
+            stale_ratio,
             live_entries,
             dead_bytes,
         })
     }
 
-    /// Rewrite live entries to a new vLog file and update pointers in SSTs.
-    /// Note: This function assumes the caller has already checked that
-    /// analysis.live_ratio < threshold. The threshold check is done once
-    /// in the caller (post_compaction_gc) to avoid inconsistency.
+    /// Rewrite live entries to a new vLog file and update the LSM index.
+    /// Old SSTs are NOT rewritten; stale pointers are shadowed by new LSM writes.
     pub fn compact_file(&self, analysis: &GcAnalysis) -> Result<()> {
+        if analysis.stale_ratio < self.threshold {
+            return Ok(());
+        }
+
         // Create new vLog file with live entries
         let new_file_id = self.vlog.next_file_id();
         let mut writer = ValueLogWriter::create(self.vlog.path_of_file(new_file_id))?;
-        
-        // Map: old_ptr -> new_ptr
-        let mut pointer_map: HashMap<ValuePointer, ValuePointer> = HashMap::new();
 
-        // Rewrite live entries preserving both key and value
+        // Rewrite live entries and update LSM index
         for entry in &analysis.live_entries {
-            // Must include the key for future GC liveness checks
             let new_ptr = writer.append(&entry.key, &entry.value)?;
-            pointer_map.insert(entry.ptr, new_ptr);
+            // Re-insert key with new pointer into LSM tree. Old SSTs still contain
+            // stale pointers, but LSM levels above them (memtable, newer SSTs)
+            // shadow those old entries with the updated pointer.
+            let mut buf = Vec::with_capacity(ValuePointer::encoded_size());
+            new_ptr.encode(&mut buf);
+            self.lsm.put(&entry.key, &buf)?;
         }
 
         writer.close()?;
 
-        // Update SSTs that reference this vLog file
-        // This rewrites affected SSTs to update value pointers, which adds
-        // write amplification. The GC threshold should account for this cost.
-        self.update_sst_pointers(analysis.file_id, &pointer_map)?;
+        // Ensure new vLog entries and LSM writes are durable before removing old file
+        self.lsm.sync()?;
 
-        // Remove old vLog file
+        // Remove old vLog file and invalidate cache
         self.vlog.remove_file(analysis.file_id)?;
 
         Ok(())
     }
 
-    /// Update value pointers in SSTs that reference the old vLog file.
-    /// This is expensive as it requires rewriting SSTs, but is necessary
-    /// because SSTs are immutable. The strategy:
-    /// 1. Find all SSTs referencing the old vLog file (using sst_to_vlogs)
-    /// 2. For each SST, read entries and rewrite with updated pointers
-    /// 3. Atomically replace old SSTs with new ones
-    /// 4. Update manifest to reflect new SST IDs
-    /// 
-    /// Performance note: To minimize write amplification, we batch SST updates
-    /// and only trigger this when the space savings justify the rewrite cost.
-    fn update_sst_pointers(
-        &self,
-        old_file_id: u32,
-        pointer_map: &HashMap<ValuePointer, ValuePointer>,
-    ) -> Result<()> {
-        // Get all SSTs referencing this vLog file
-        let affected_ssts = self.vlog.get_ssts_referencing(old_file_id);
-        
-        for sst_id in affected_ssts {
-            // Rewrite SST with updated pointers
-            let new_sst_id = self.rewrite_sst_with_new_pointers(sst_id, pointer_map)?;
-            
-            // Update manifest atomically
-            self.vlog.update_sst_reference(sst_id, new_sst_id, old_file_id)?;
-        }
-        
-        Ok(())
-    }
-
     /// Check if a vLog entry is still referenced by the LSM tree.
     fn is_entry_live(&self, entry: &VlogEntry) -> Result<bool> {
-        // Query the LSM tree to see if this key still references this vLog entry
-        let key = &entry.key;
-        match self.lsm.get(key)? {
+        match self.lsm.get(&entry.key)? {
             Some(value) => {
-                // Decode value pointer and check if it matches
                 if value.len() == ValuePointer::encoded_size() {
                     let ptr = ValuePointer::decode(&value);
                     Ok(ptr.file_id == entry.ptr.file_id && ptr.offset == entry.ptr.offset)
@@ -493,6 +539,21 @@ impl GarbageCollector {
         }
     }
 }
+
+### 7.1 Stale Pointer Handling
+
+Because SSTs are immutable, old SSTs continue to contain pointers to the old vLog file even after GC moves values to a new file. This is handled naturally by the LSM tree's tiered structure:
+
+- New GC writes go to the **memtable** first
+- `get()` searches memtable → immutable memtables → L0 → L1 → ...
+- The new pointer in the memtable (or a recently flushed SST) shadows the old pointer
+- Range scans may encounter both old and new pointers; merge iterators deduplicate by key
+- Eventually, compaction removes old SSTs containing stale pointers entirely
+
+If a `get()` reads a stale pointer from an old SST after the old vLog file has been deleted, it will get an I/O error. To prevent this, GC must only delete old vLog files after:
+1. All live entries are rewritten to the new vLog file
+2. The new pointers are durably written to the LSM tree (via `sync()`)
+3. No active snapshots or iterators are reading the old file
 ```
 
 ### 8. Integration with Compaction
@@ -505,6 +566,7 @@ impl CompactionController {
         input_ssts: &[usize],
         output_ssts: &[usize],
         vlog: &Arc<ValueLog>,
+        lsm: &Arc<MiniLsm>,
     ) -> Result<()> {
         // Collect all vLog files referenced by input SSTs
         let mut affected_vlogs: HashSet<u32> = HashSet::new();
@@ -516,20 +578,20 @@ impl CompactionController {
         }
 
         // Run GC analysis on affected files
-        let gc = GarbageCollector::new(vlog.clone(), self.lsm.clone(), vlog.options().gc_threshold_ratio);
+        let gc = GarbageCollector::new(vlog.clone(), lsm.clone(), vlog.options().gc_threshold_ratio);
         for file_id in affected_vlogs {
             let analysis = gc.analyze_file(file_id)?;
-            if analysis.live_ratio < vlog.options().gc_threshold_ratio {
+            if analysis.stale_ratio >= vlog.options().gc_threshold_ratio {
                 gc.compact_file(&analysis)?;
             }
         }
 
-        // Update references for output SSTs
-        // Output SSTs register their vLog references during SST construction
-        // The SST builder calls register_sst_references() when finalizing each SST
+        // Register vLog references for output SSTs.
+        // In practice, each output SST is built by an SsTableBuilder which already
+        // populates referenced_vlogs. When the SST is finalized, the builder's
+        // referenced_vlogs set is passed to vlog.register_sst_references().
         for sst_id in output_ssts {
-            // SSTs created during compaction will register themselves
-            // via their builder's referenced_vlogs set
+            // SST builders register references automatically during finalization.
         }
 
         Ok(())
@@ -749,6 +811,15 @@ pub enum ManifestRecord {
     DeleteVlogFile(u32),
 }
 ```
+
+## Crash Recovery
+
+Because vLog files are append-only and written before their corresponding SSTs, crash recovery follows these ordering rules:
+
+1. **vLog writes happen before SST writes**: When flushing a memtable, values are first appended to the vLog, then the SST is built with pointers to those vLog locations.
+2. **SST atomically installed**: The SST is only added to the LSM state (and manifest updated) after both vLog and SST files are fully written and synced.
+3. **Recovery on restart**: The manifest is replayed as usual. Any vLog files referenced by SSTs in the manifest are valid. vLog files not referenced by any SST can be garbage collected on startup.
+4. **Partial vLog write**: If a crash occurs during vLog writing, the partially written entry is detected by CRC32 mismatch and skipped during reads.
 
 ## Performance Considerations
 

--- a/rfcs/001-key-value-separation.md
+++ b/rfcs/001-key-value-separation.md
@@ -97,17 +97,33 @@ pub struct ValuePointer {
     pub size: u32,
 }
 
+/// Magic tag byte that prefixes every encoded `ValuePointer`.
+///
+/// Without an explicit tag, any 16-byte inline value (UUID, hash, small blob,
+/// etc.) would be indistinguishable from an encoded pointer. The tag makes the
+/// encoding self-describing so `try_decode` can safely classify a value during
+/// compaction or GC analysis. `0xFF` is chosen because it is an extremely
+/// uncommon prefix for legitimate user payloads; a stronger guarantee can be
+/// obtained by also tracking the type via a per-entry meta flag in the SST
+/// (see `KvKind` in section 5).
+const VALUE_POINTER_TAG: u8 = 0xFF;
+
 impl ValuePointer {
-    /// Encode to bytes for storage in LSM tree
+    /// Encode to bytes for storage in LSM tree.
+    ///
+    /// Layout (17 bytes): `[tag:1][file_id:4][offset:8][size:4]`
     pub fn encode(&self, buf: &mut Vec<u8>) {
+        buf.put_u8(VALUE_POINTER_TAG);
         buf.put_u32(self.file_id);
         buf.put_u64(self.offset);
         buf.put_u32(self.size);
     }
 
-    /// Decode from bytes. Panics if the buffer is shorter than 16 bytes.
+    /// Decode from bytes. Panics if the buffer is malformed.
     pub fn decode(mut buf: &[u8]) -> Self {
         assert!(buf.len() >= Self::encoded_size(), "ValuePointer buffer too short");
+        let tag = buf.get_u8();
+        assert_eq!(tag, VALUE_POINTER_TAG, "ValuePointer tag mismatch");
         Self {
             file_id: buf.get_u32(),
             offset: buf.get_u64(),
@@ -115,20 +131,20 @@ impl ValuePointer {
         }
     }
 
-    /// Try to decode from bytes. Returns None if the buffer is too short.
-    /// 
-    /// Note: In production, a type tag or prefix byte should be used to
-    /// unambiguously distinguish ValuePointer from inline 16-byte values.
+    /// Try to decode from bytes. Returns `None` if the buffer is too short or
+    /// does not start with the `VALUE_POINTER_TAG` byte. This makes the
+    /// classification of "inline value" vs. "value pointer" unambiguous, so an
+    /// inline 16-byte UUID can never be mistaken for a pointer.
     pub fn try_decode(buf: &[u8]) -> Option<Self> {
-        if buf.len() < Self::encoded_size() {
+        if buf.len() < Self::encoded_size() || buf[0] != VALUE_POINTER_TAG {
             return None;
         }
         Some(Self::decode(buf))
     }
 
-    /// Total encoded size: 16 bytes
+    /// Total encoded size: 17 bytes (1-byte tag + 4 + 8 + 4)
     pub const fn encoded_size() -> usize {
-        4 + 8 + 4 // 16 bytes
+        1 + 4 + 8 + 4 // 17 bytes
     }
 }
 ```
@@ -146,14 +162,18 @@ impl ValuePointer {
 │  └───────────┴─────────┴───────────┴───────────┘                   │
 │                                                                     │
 │  Header Format (16 bytes total):                                    │
-│  ┌─────────────┬───────────────┬─────────────┬─────────────┬──────────┐
-│  │ crc32       │ key_length    │ value_length│ flags       │ padding  │
-│  │ (4 bytes)   │ (2 bytes)     │ (4 bytes)   │ (2 bytes)   │ (4 bytes)│
-│  └─────────────┴───────────────┴─────────────┴─────────────┴──────────┘
+│  ┌─────────────┬─────────────┬─────────────┬───────────────┬──────────┐
+│  │ crc32       │ value_length│ key_length  │ flags         │ padding  │
+│  │ (4 bytes)   │ (4 bytes)   │ (2 bytes)   │ (2 bytes)     │ (4 bytes)│
+│  └─────────────┴─────────────┴─────────────┴───────────────┴──────────┘
 │                                                                     │
-│  CRC32: Covers key + value payload for integrity validation         │
+│  CRC32: Covers (header_without_crc) + key + value to detect         │
+│         corruption of length fields as well as the payload          │
 │                                                                     │
-│  Alignment: Entries are 8-byte aligned for efficient disk access    │
+│  Alignment: Each entry (header + key + value) is padded to an       │
+│             8-byte boundary on disk; the trailing pad bytes are     │
+│             included in the entry's `size` so readers can skip      │
+│             cleanly to the next entry.                              │
 │                                                                     │
 └─────────────────────────────────────────────────────────────────────┘
 ```
@@ -170,18 +190,22 @@ pub struct VlogFileHeader {
     pub reserved: [u8; 10],   // 10 bytes padding to align to 16 bytes total
 }
 
-/// Entry header (precedes each key-value pair)
-/// Total size: 16 bytes for 8-byte alignment
+/// Entry header (precedes each key-value pair).
+///
+/// Field order is chosen so that all u32 fields come before u16 fields, which
+/// keeps the C struct layout naturally 4-byte-aligned with no implicit padding
+/// between the declared fields. The trailing `_padding` brings the total to a
+/// flat 16 bytes and preserves the file's 8-byte alignment guarantee.
 #[repr(C)]
 pub struct VlogEntryHeader {
-    pub crc32: u32,           // CRC32 of key + value (4 bytes)
-    pub key_len: u16,         // Key length (max 64KB). Large keys must be stored inline. (2 bytes)
+    pub crc32: u32,           // CRC32 of the rest of the header + key + value (4 bytes)
     pub value_len: u32,       // Value length (max 4GB) (4 bytes)
+    pub key_len: u16,         // Key length (max 64KB). Large keys must be stored inline. (2 bytes)
     pub flags: u16,           // Flags (tombstone, etc.) (2 bytes)
-    pub _padding: [u8; 4],    // Padding to 16 bytes for alignment
+    pub _padding: [u8; 4],    // Reserved / padding to a 16-byte total
 }
 
-const HEADER_SIZE: usize = std::mem::size_of::<VlogEntryHeader>();
+const HEADER_SIZE: usize = std::mem::size_of::<VlogEntryHeader>(); // 16
 const ALIGNMENT: usize = 8;
 ```
 
@@ -197,14 +221,26 @@ pub struct ValueLogBuilder {
 }
 
 impl ValueLogBuilder {
-    /// Add a key-value pair to the vLog. Returns a ValuePointer.
+    /// Add a key-value pair to the vLog. Returns a `ValuePointer`.
+    ///
+    /// The on-disk footprint of an entry is `header + key + value`, padded up
+    /// to the next `ALIGNMENT` (8-byte) boundary. The pad bytes are written to
+    /// disk *and* counted in `ValuePointer::size`, so a reader can validate
+    /// the entry and advance to the next one without re-reading the header.
     pub fn add(&mut self, key: &[u8], value: &[u8]) -> ValuePointer {
         let offset = self.writer.offset();
-        self.writer.append(key, value);
+        let payload = HEADER_SIZE + key.len() + value.len();
+        let padded = (payload + ALIGNMENT - 1) & !(ALIGNMENT - 1);
+        let pad = padded - payload;
+
+        self.writer.append_with_pad(key, value, pad);
+
+        debug_assert_eq!(self.writer.offset() % ALIGNMENT as u64, 0);
+
         ValuePointer {
             file_id: self.file_id,
             offset,
-            size: (key.len() + value.len() + HEADER_SIZE) as u32,
+            size: padded as u32,
         }
     }
 }
@@ -433,12 +469,46 @@ impl ValueLog {
         Ok(())
     }
 
-    /// Schedule a vLog file for deletion once all readers are quiesced.
-    /// In production, this uses watermark-based epoch reclamation or reference counting.
+    /// Mark a vLog file as obsolete and queue it for deletion. The file is
+    /// **not** unlinked here — that would race with active snapshots,
+    /// iterators, and any in-flight reads through stale pointers in older
+    /// SSTs. Instead the file is parked on a pending-deletion queue and a
+    /// background task reclaims it once it is safe.
+    ///
+    /// Safety condition (any one is sufficient):
+    /// - the file's reader/iterator refcount has dropped to zero, **and**
+    /// - the MVCC watermark has advanced past the timestamp at which the file
+    ///   was retired (so no snapshot can still hold a pointer into it), **and**
+    /// - all SSTs that referenced this `file_id` have been compacted away
+    ///   (so no `get()` can produce a stale pointer to it).
+    ///
+    /// `obsolete_at_ts` is the engine's current commit timestamp / epoch at
+    /// the moment GC retired the file, used by the watermark check.
     pub fn schedule_deletion(&self, file_id: u32) -> Result<()> {
-        // TODO: integrate with snapshot watermark / epoch-based reclamation
-        // For now, defer to a background cleanup task that checks active snapshots.
-        self.remove_file(file_id)
+        let obsolete_at_ts = self.lsm_clock.now();
+        self.pending_deletions
+            .lock()
+            .push(PendingDeletion { file_id, obsolete_at_ts });
+        Ok(())
+    }
+
+    /// Background reclamation pass. Walks the pending queue and unlinks any
+    /// file that has cleared all of the deferred-deletion conditions above.
+    /// Run on a timer or at the tail of every successful compaction.
+    pub fn reclaim_pending_deletions(&self, watermark_ts: u64) -> Result<()> {
+        let mut pending = self.pending_deletions.lock();
+        pending.retain(|p| {
+            let safe = p.obsolete_at_ts <= watermark_ts
+                && self.reader_refcount(p.file_id) == 0
+                && self.get_ssts_referencing(p.file_id).is_empty();
+            if safe {
+                let _ = self.remove_file(p.file_id);
+                false // drop from queue
+            } else {
+                true // keep, retry later
+            }
+        });
+        Ok(())
     }
 }
 ```
@@ -519,6 +589,15 @@ impl GarbageCollector {
 
     /// Rewrite live entries to a new vLog file and update the LSM index.
     /// Old SSTs are NOT rewritten; stale pointers are shadowed by new LSM writes.
+    ///
+    /// **Race avoidance**: a user `put`/`delete` can land on a key between
+    /// the `is_entry_live` check and the GC re-insert. To make sure GC never
+    /// shadows fresher user writes, we re-validate the pointer atomically
+    /// (under a per-key guard or via the LSM's MVCC sequence number) right
+    /// before insertion, and only insert when the LSM still observes the
+    /// *exact* old pointer for that key. If the key has been overwritten or
+    /// deleted in the meantime, the new pointer is discarded — the new vLog
+    /// entry is simply unreferenced and will be reclaimed by the next GC pass.
     pub fn compact_file(&self, analysis: &GcAnalysis) -> Result<()> {
         if analysis.stale_ratio < self.threshold {
             return Ok(());
@@ -531,22 +610,31 @@ impl GarbageCollector {
         // Rewrite live entries and update LSM index
         for entry in &analysis.live_entries {
             let new_ptr = writer.append(&entry.key, &entry.value)?;
-            // Re-insert key with new pointer into LSM tree. Old SSTs still contain
-            // stale pointers, but LSM levels above them (memtable, newer SSTs)
-            // shadow those old entries with the updated pointer.
             let mut buf = Vec::with_capacity(ValuePointer::encoded_size());
             new_ptr.encode(&mut buf);
-            self.lsm.put(&entry.key, &buf)?;
+
+            // Atomic rebind: only swap the pointer if the key still resolves
+            // to `entry.ptr`. `compare_and_set` performs the get + put under
+            // the same MVCC sequence so a concurrent user write cannot be
+            // overwritten. Implementations without explicit CAS can serialize
+            // GC writes with the write batch lock and re-check `is_entry_live`
+            // inside the critical section.
+            self.lsm.compare_and_set(
+                &entry.key,
+                /* expected = */ &entry.ptr,
+                /* new      = */ &buf,
+            )?;
         }
 
         writer.close()?;
 
-        // Ensure new vLog entries and LSM writes are durable before removing old file
+        // Ensure new vLog entries and LSM writes are durable before scheduling
+        // the old file for reclamation.
         self.lsm.sync()?;
 
-        // Defer deletion until all active snapshots/iterators referencing the old
-        // file have been released. In a production system, this uses reference
-        // counting or watermark-based epoch reclamation (see Stale Pointer Handling).
+        // Defer deletion until all active snapshots/iterators referencing the
+        // old file have been released. See `ValueLog::schedule_deletion` and
+        // section 7.1 for the watermark/refcount-based reclamation contract.
         self.vlog.schedule_deletion(analysis.file_id)?;
 
         Ok(())
@@ -559,7 +647,7 @@ impl GarbageCollector {
                 if let Some(ptr) = ValuePointer::try_decode(&value) {
                     Ok(ptr.file_id == entry.ptr.file_id && ptr.offset == entry.ptr.offset)
                 } else {
-                    Ok(false) // Value is now inline (or ambiguous 16-byte value)
+                    Ok(false) // Value is now inline (untagged) — not a pointer
                 }
             }
             None => Ok(false), // Key was deleted
@@ -835,17 +923,36 @@ pub struct SsTableFooter {
 
 ### Manifest Changes
 
+Manifest records are extended to carry the SST → vLog reference set so that
+recovery can rebuild `sst_to_vlogs` directly from the manifest log instead of
+re-opening every SST footer. This keeps startup O(manifest size) rather than
+O(total SST count) once vLog adoption grows.
+
 ```rust
 #[derive(Serialize, Deserialize)]
 pub enum ManifestRecord {
-    Flush(usize),
+    /// Flush of a memtable to L0. Carries the vLog files this new SST
+    /// references (empty if the SST has no separated values).
+    Flush(usize, Vec<u32>),
+
     NewMemtable(usize),
-    Compaction(CompactionTask, Vec<usize>),
-    // NEW: Track vLog file lifecycle
+
+    /// Compaction output. For each output SST, record the set of vLog files
+    /// it references so the SST → vLog map is reconstructable from the
+    /// manifest alone.
+    Compaction(CompactionTask, Vec<(usize, Vec<u32>)>),
+
+    /// vLog file lifecycle.
     NewVlogFile(u32),
     DeleteVlogFile(u32),
 }
 ```
+
+Recovery walks the manifest as before; for every `Flush` / `Compaction` record
+it inserts the carried `(sst_id, vlog_ids)` pairs into `sst_to_vlogs`. SSTable
+footers still embed the vLog reference list as a redundant copy, used by
+`fsck`-style consistency checks and by older snapshots whose manifest record
+predates this format.
 
 ## Crash Recovery
 

--- a/rfcs/001-key-value-separation.md
+++ b/rfcs/001-key-value-separation.md
@@ -154,9 +154,9 @@ impl ValuePointer {
     /// Layout (17 bytes): `[tag:1][file_id:4][offset:8][size:4]`
     pub fn encode(&self, buf: &mut Vec<u8>) {
         buf.put_u8(VALUE_POINTER_TAG);
-        buf.put_u32(self.file_id);
-        buf.put_u64(self.offset);
-        buf.put_u32(self.size);
+        buf.put_u32_le(self.file_id);
+        buf.put_u64_le(self.offset);
+        buf.put_u32_le(self.size);
     }
 
     /// Decode from bytes. Returns an error if the buffer is malformed.
@@ -169,9 +169,9 @@ impl ValuePointer {
             return Err(anyhow!("ValuePointer tag mismatch: expected 0x{:02X}, got 0x{:02X}", VALUE_POINTER_TAG, tag));
         }
         Ok(Self {
-            file_id: buf.get_u32(),
-            offset: buf.get_u64(),
-            size: buf.get_u32(),
+            file_id: buf.get_u32_le(),
+            offset: buf.get_u64_le(),
+            size: buf.get_u32_le(),
         })
     }
 
@@ -190,9 +190,9 @@ impl ValuePointer {
         // and anyhow error construction in the hot path.
         let mut b = &buf[1..];
         Some(Self {
-            file_id: b.get_u32(),
-            offset: b.get_u64(),
-            size: b.get_u32(),
+            file_id: b.get_u32_le(),
+            offset: b.get_u64_le(),
+            size: b.get_u32_le(),
         })
     }
 
@@ -301,6 +301,11 @@ impl ValueLogBuilder {
         let offset = self.writer.offset();
 
         // Validate BEFORE writing to avoid corrupting the vLog with an oversized entry.
+        anyhow::ensure!(
+            key.len() <= u16::MAX as usize,
+            "key length {} exceeds vLog header u16 capacity",
+            key.len()
+        );
         let entry_size = HEADER_SIZE + key.len() + value.len();
         let padding = (ALIGNMENT - (entry_size % ALIGNMENT)) % ALIGNMENT;
         let total = entry_size + padding;
@@ -620,6 +625,18 @@ impl ValueLog {
     /// Updates both forward and reverse indexes atomically under one lock.
     pub fn register_sst_references(&self, sst_id: usize, vlog_ids: HashSet<u32>) {
         let mut refs = self.vlog_refs.write();
+        // Unregister any existing references for this SST first to prevent
+        // stale entries in the reverse index from leaking.
+        if let Some(old_vlogs) = refs.sst_to_vlogs.remove(&sst_id) {
+            for vlog_id in old_vlogs {
+                if let Some(ssts) = refs.vlog_to_ssts.get_mut(&vlog_id) {
+                    ssts.remove(&sst_id);
+                    if ssts.is_empty() {
+                        refs.vlog_to_ssts.remove(&vlog_id);
+                    }
+                }
+            }
+        }
         for vlog_id in &vlog_ids {
             refs.vlog_to_ssts.entry(*vlog_id).or_default().insert(sst_id);
         }
@@ -665,11 +682,12 @@ impl ValueLog {
     pub fn read(self: &Arc<ValueLog>, ptr: &ValuePointer, expected_key: &[u8]) -> Result<Bytes> {
         // Defensive validation: a corrupted ptr.size (up to u32::MAX) could
         // cause an OOM panic in read_entry. Reject implausible sizes early.
+        let min_entry = HEADER_SIZE + expected_key.len();
         let max_entry = self.options.max_value_size + HEADER_SIZE + expected_key.len() + ALIGNMENT;
         anyhow::ensure!(
-            ptr.size as usize <= max_entry,
-            "ValuePointer size {} exceeds maximum allowed entry size {}",
-            ptr.size, max_entry
+            ptr.size as usize >= min_entry && ptr.size as usize <= max_entry,
+            "ValuePointer size {} is invalid (must be between {} and {})",
+            ptr.size, min_entry, max_entry
         );
         let reader = self.get_reader(ptr.file_id)?;
         let entry = reader.read_entry(ptr.offset, ptr.size)?;
@@ -700,7 +718,7 @@ impl ValueLog {
                 .or_insert_with(|| Arc::new(AtomicUsize::new(0)))
                 .clone()
         };
-        counter.fetch_add(1, Ordering::Acquire);
+        counter.fetch_add(1, Ordering::AcqRel);
         Ok(ValueLogReaderHandle { reader, vlog: self.clone(), file_id, counter })
     }
 

--- a/rfcs/001-key-value-separation.md
+++ b/rfcs/001-key-value-separation.md
@@ -286,13 +286,17 @@ impl ValueLogBuilder {
         let offset = self.writer.offset();
 
         // Validate BEFORE writing to avoid corrupting the vLog with an oversized entry.
-        let total = self.writer.append(key, value);
+        let entry_size = HEADER_SIZE + key.len() + value.len();
+        let padding = (ALIGNMENT - (entry_size % ALIGNMENT)) % ALIGNMENT;
+        let total = entry_size + padding;
         assert!(
             total <= u32::MAX as usize,
             "vLog entry size {} exceeds u32 capacity — increase max_value_size or reduce key/value size",
             total
         );
 
+        let written = self.writer.append(key, value);
+        debug_assert_eq!(written, total);
         debug_assert_eq!(self.writer.offset() % ALIGNMENT as u64, 0);
 
         ValuePointer {
@@ -418,9 +422,9 @@ impl SsTableBuilder {
         let (value_to_store, kind) = if let Some(k) = input_kind {
             // Compaction path: trust the caller's authoritative metadata.
             if k == KvKind::ValuePointer {
-                if let Some(vptr) = ValuePointer::try_decode(value) {
-                    self.referenced_vlogs.insert(vptr.file_id);
-                }
+                let vptr = ValuePointer::decode(value)
+                    .expect("failed to decode ValuePointer during compaction — metadata is authoritative");
+                self.referenced_vlogs.insert(vptr.file_id);
             }
             (value, k)
         } else if self.should_separate_value(key, value) {
@@ -583,7 +587,13 @@ impl ValueLog {
             self.rotate_vlog_file(&mut writer)?;
         }
 
-        writer.append(key, value)
+        let offset = writer.offset();
+        let total = writer.append(key, value)?;
+        Ok(ValuePointer {
+            file_id: writer.file_id(),
+            offset,
+            size: total as u32,
+        })
     }
 
     /// Register SST -> vLog references when an SST is finalized.
@@ -876,7 +886,13 @@ impl GarbageCollector {
         let mut rewrites: Vec<(Vec<u8>, ValuePointer, ValuePointer)> = Vec::new();
         for entry_ref in &analysis.live_entries {
             let value = self.vlog.read(&entry_ref.ptr, &entry_ref.key)?;
-            let new_ptr = writer.append(&entry_ref.key, &value)?;
+            let offset = writer.offset();
+            let total = writer.append(&entry_ref.key, &value)?;
+            let new_ptr = ValuePointer {
+                file_id: new_file_id,
+                offset,
+                size: total as u32,
+            };
             rewrites.push((entry_ref.key.clone(), entry_ref.ptr, new_ptr));
         }
 

--- a/rfcs/001-key-value-separation.md
+++ b/rfcs/001-key-value-separation.md
@@ -610,24 +610,28 @@ impl ValueLog {
         let reader = self.readers.try_get_with(file_id, || {
             ValueLogReader::open(self.path_of_file(file_id)).map(Arc::new)
         }).map_err(|e| anyhow!("Failed to open vlog {}: {}", file_id, e))?;
-        // Get or create per-file atomic counter. Write lock only on first access.
-        let counter = self.reader_refcounts
-            .write()
-            .entry(file_id)
-            .or_insert_with(|| Arc::new(AtomicUsize::new(0)))
-            .clone();
+        // Get or create per-file atomic counter. Read lock first to avoid
+        // contention on the common path (counter already exists).
+        let counter = if let Some(c) = self.reader_refcounts.read().get(&file_id) {
+            c.clone()
+        } else {
+            self.reader_refcounts
+                .write()
+                .entry(file_id)
+                .or_insert_with(|| Arc::new(AtomicUsize::new(0)))
+                .clone()
+        };
         counter.fetch_add(1, Ordering::Relaxed);
         Ok(ValueLogReaderHandle { reader, vlog: self.clone(), file_id, counter })
     }
 
     /// Decrements the reference count for a vLog file reader.
     /// Called when a `ValueLogReaderHandle` is dropped.
-    fn release_reader(&self, file_id: u32, counter: &AtomicUsize) {
+    /// Counter map entries are NOT removed here to avoid write-lock contention
+    /// on the hot path. Stale entries are cleaned up periodically by
+    /// `cleanup_stale_counters` or left in place (they are small).
+    fn release_reader(&self, _file_id: u32, counter: &AtomicUsize) {
         counter.fetch_sub(1, Ordering::Relaxed);
-        // Clean up map entry when count reaches zero (best-effort).
-        if counter.load(Ordering::Relaxed) == 0 {
-            self.reader_refcounts.write().remove(&file_id);
-        }
     }
 
     /// Returns the current open-reader reference count for a vLog file.
@@ -1234,11 +1238,14 @@ Because vLog files are append-only and written before their corresponding SSTs, 
 
 ### WAL Interaction
 
-To avoid doubling write amplification by writing large values to both the WAL and the vLog, the WAL should store only the `ValuePointer` for separated values (not the full value). The vLog write is the durable copy; the WAL entry just records the pointer so recovery can reconstruct the memtable. This means:
+To avoid doubling write amplification by writing large values to both the WAL and the vLog, the WAL stores only the `ValuePointer` for separated values (not the full value). The vLog write must be synced **before** the WAL entry is committed to prevent dangling pointers on crash:
 
-- **Write path**: value → vLog (durable) → WAL (pointer only) → memtable
-- **Recovery**: replay WAL; for entries with ValuePointer, the pointer is already correct — no vLog re-read needed
+- **Write path**: value → vLog append → **vLog sync** → WAL (pointer only) → memtable
+- **Recovery**: replay WAL; for entries with ValuePointer, the pointer is already durable — no vLog re-read needed
 - **Crash before vLog sync**: the WAL entry is also incomplete (write ordering), so the entry is lost — this is the same guarantee as a non-separated write
+- **Crash after WAL commit**: vLog is guaranteed synced (ordering above), so the pointer is always valid
+
+**Performance note**: the extra `sync()` call on the vLog adds latency per separated write. This can be amortized by batching multiple vLog appends before a single sync (group commit), which is the natural result of the Mutex on `active_writer`.
 
 ## Performance Considerations
 

--- a/rfcs/001-key-value-separation.md
+++ b/rfcs/001-key-value-separation.md
@@ -359,13 +359,16 @@ impl SsTableBuilder {
             (&self.vlog_buffer[..ValuePointer::encoded_size()], KvKind::ValuePointer)
         } else {
             // During compaction, values may already be encoded ValuePointers.
-            // Use KvKind metadata (authoritative) rather than try_decode alone.
+            // Detect existing pointers and preserve KvKind so readers dereference
+            // them correctly instead of returning raw pointer bytes.
+            let mut kind = KvKind::Inline;
             if value.len() == ValuePointer::encoded_size() && value[0] == VALUE_POINTER_TAG {
                 if let Some(vptr) = ValuePointer::try_decode(value) {
                     self.referenced_vlogs.insert(vptr.file_id);
+                    kind = KvKind::ValuePointer;
                 }
             }
-            (value, KvKind::Inline)
+            (value, kind)
         };
 
         // Each block entry now carries (key, value, KvKind) so that the
@@ -410,6 +413,26 @@ pub struct PendingDeletion {
     file_id: u32,
     /// The engine timestamp / epoch at the moment GC retired this file.
     obsolete_at_ts: u64,
+}
+
+/// RAII guard for a cached vLog reader. Automatically decrements the
+/// ValueLog's reader_refcount when dropped, preventing retired vLog files
+/// from being unlinked while an iterator or snapshot still reads them.
+pub struct ValueLogReaderHandle {
+    reader: Arc<ValueLogReader>,
+    vlog: ValueLog,  // Clone (Arc-backed) for drop-time release
+    file_id: u32,
+}
+
+impl std::ops::Deref for ValueLogReaderHandle {
+    type Target = ValueLogReader;
+    fn deref(&self) -> &Self::Target { &self.reader }
+}
+
+impl Drop for ValueLogReaderHandle {
+    fn drop(&mut self) {
+        self.vlog.release_reader(self.file_id);
+    }
 }
 
 /// Manages value log files for the storage engine.
@@ -503,13 +526,14 @@ impl ValueLog {
     }
 
     /// Get a cached reader for the specified vLog file.
-    fn get_reader(&self, file_id: u32) -> Result<Arc<ValueLogReader>> {
+    /// Returns a RAII guard that decrements the refcount on drop.
+    fn get_reader(&self, file_id: u32) -> Result<ValueLogReaderHandle> {
         let reader = self.readers.try_get_with(file_id, || {
             ValueLogReader::open(self.path_of_file(file_id)).map(Arc::new)
         }).map_err(|e| anyhow!("Failed to open vlog {}: {}", file_id, e))?;
         // Track open-reader reference count for safe deferred deletion.
         *self.reader_refcounts.write().entry(file_id).or_insert(0) += 1;
-        Ok(reader)
+        Ok(ValueLogReaderHandle { reader, vlog: self.clone(), file_id })
     }
 
     /// Decrements the reference count for a vLog file reader.
@@ -807,10 +831,21 @@ impl CompactionController {
             // SST builders register references automatically during finalization.
         }
 
+        // Clean up vLog references for input SSTs that are being replaced.
+        // Without this, get_ssts_referencing() would still return stale SST IDs,
+        // preventing reclaim_pending_deletions() from ever unlinking retired vLogs.
+        for sst_id in input_ssts {
+            vlog.unregister_sst_references(*sst_id);
+        }
+
         Ok(())
     }
 }
 ```
+
+**Important**: `unregister_sst_references(sst_id)` removes the SST's entry from the
+`sst_to_vlogs` mapping. This must be called whenever an SST is deleted (compaction,
+manual removal) to prevent leaked references that block vLog space reclamation.
 
 ## Implementation Plan
 

--- a/rfcs/001-key-value-separation.md
+++ b/rfcs/001-key-value-separation.md
@@ -266,13 +266,14 @@ pub struct VlogEntryHeader {
     pub flags: u16,           // Flags (tombstone, etc.) (2 bytes)
     pub _padding: [u8; 4],    // Reserved / padding to a 16-byte total
 }
-// NOTE: The CRC32 covers the rest of the header + key + value, so a
-// header-only iterator (which skips the value payload) cannot validate
-// the checksum. To allow header-only validation and resynchronization
-// after corruption, the on-disk format should prepend a 4-byte magic
-// marker (e.g., 0x76_4C_6F_67 = "vLog") before each entry header.
-// A header-only scanner can then skip forward to the next magic marker
-// if the current header's fields are implausible (e.g., value_len > max).
+// NOTE: To allow robust header-only validation and resynchronization
+// after corruption, the on-disk format should use a split checksum:
+// 1. A 4-byte CRC32 covering the header and key (allowing the header-only
+//    iterator to fully validate integrity and safely skip the value).
+// 2. A separate CRC32 covering the value payload.
+// The current single-CRC32 design means a corrupted value_len or key_len
+// cannot be detected without reading the full entry, which risks
+// desynchronization during header-only scans.
 
 const HEADER_SIZE: usize = 16; // VlogEntryHeader is always 16 bytes
 const ALIGNMENT: usize = 8;
@@ -662,6 +663,14 @@ impl ValueLog {
     /// `expected_key` is validated against the stored key to detect stale or
     /// corrupted pointers that land on a different entry's offset.
     pub fn read(self: &Arc<ValueLog>, ptr: &ValuePointer, expected_key: &[u8]) -> Result<Bytes> {
+        // Defensive validation: a corrupted ptr.size (up to u32::MAX) could
+        // cause an OOM panic in read_entry. Reject implausible sizes early.
+        let max_entry = self.options.max_value_size + HEADER_SIZE + expected_key.len() + ALIGNMENT;
+        anyhow::ensure!(
+            ptr.size as usize <= max_entry,
+            "ValuePointer size {} exceeds maximum allowed entry size {}",
+            ptr.size, max_entry
+        );
         let reader = self.get_reader(ptr.file_id)?;
         let entry = reader.read_entry(ptr.offset, ptr.size)?;
         if entry.key != expected_key {
@@ -988,7 +997,7 @@ Because SSTs are immutable, old SSTs continue to contain pointers to the old vLo
 If a `get()` reads a stale pointer from an old SST after the old vLog file has been deleted, it will get an I/O error. To prevent this, GC must only delete old vLog files after:
 1. All live entries are rewritten to the new vLog file
 2. The new pointers are durably written to the LSM tree (via `sync()`)
-3. No active snapshots or iterators are reading the old file
+3. No active snapshots, iterators, or open SSTables are referencing the old file. This can be achieved by having each `SsTable` instance hold a shared reference/handle to the vLog files it references, keeping the files open and preventing physical deletion until the `SsTable` is dropped.
 
 **Deferred Deletion Strategy:**
 
@@ -1330,6 +1339,9 @@ pub enum ManifestRecord {
 Recovery walks the manifest as before; for every `Flush` / `FlushV2` /
 `Compaction` / `CompactionV2` record it calls `register_sst_references(sst_id,
 vlog_ids)` to populate **both** `sst_to_vlogs` and `vlog_to_ssts` indexes.
+Additionally, for compaction records, it extracts the input SST IDs from the
+`CompactionTask` and calls `unregister_sst_references` for each, preventing
+reference leaks that would block vLog garbage collection.
 Old `Flush(usize)` and `Compaction(usize, Vec<usize>)` records are treated as
 having an empty vLog set. SSTable footers still embed the vLog reference list
 as a redundant copy, used by `fsck`-style consistency checks and by older

--- a/rfcs/001-key-value-separation.md
+++ b/rfcs/001-key-value-separation.md
@@ -528,6 +528,14 @@ impl ValueLog {
             "key length {} exceeds vLog header u16 capacity",
             key.len()
         );
+        // Enforce max_value_size to prevent u32 overflow in ValuePointer::size
+        // and to keep GC scan times reasonable.
+        anyhow::ensure!(
+            value.len() <= self.options.max_value_size,
+            "value length {} exceeds max_value_size {}",
+            value.len(),
+            self.options.max_value_size
+        );
 
         let mut writer = self.active_writer.lock();
 
@@ -793,7 +801,14 @@ impl GarbageCollector {
     /// before insertion, and only insert when the LSM still observes the
     /// *exact* old pointer for that key. If the key has been overwritten or
     /// deleted in the meantime, the new pointer is discarded — the new vLog
-    /// entry is simply unreferenced and will be reclaimed by the next GC pass.
+    /// entry becomes orphaned (unreferenced by any SST).
+    ///
+    /// **Orphan reclamation**: entries written to the new vLog before a failed
+    /// CAS are unreferenced but occupy space. Two strategies:
+    /// (a) Track a "committed watermark" per vLog file — entries above the
+    ///     watermark are treated as dead by the next GC pass.
+    /// (b) Use a tombstone marker: on CAS failure, write a zero-length tombstone
+    ///     entry so the reader knows to skip it and the GC can reclaim the space.
     pub fn compact_file(&self, analysis: &GcAnalysis) -> Result<()> {
         if analysis.stale_ratio < self.threshold {
             return Ok(());


### PR DESCRIPTION
## Summary

This RFC proposes implementing WiscKey-style key-value separation for Mini-LSM, inspired by production systems like BadgerDB, RocksDB's BlobDB, and Titan.

## Motivation

The current Mini-LSM architecture stores keys and values together in SSTable blocks, which leads to:
- High write amplification during compaction (10x for large values)
- Inefficient range scans
- Block cache pollution

## Key Benefits

- **5-10x reduction** in write amplification for large-value workloads
- **Faster range scans** (no need to scan through large values)
- **Better cache efficiency** (keys separated from values)

## Design Highlights

- **ValuePointer**: 16-byte reference to vLog entries
- **ValueLog**: Dedicated files for large values with configurable threshold
- **Garbage Collection**: Automatic space reclamation during compaction
- **Backward Compatible**: Can be disabled, existing data unchanged

## Implementation Plan

4-phase approach over ~4 weeks:
1. Core Infrastructure (ValuePointer, vLog format, read/write)
2. SSTable Integration
3. Garbage Collection
4. Testing & Optimization

See the full RFC in rfcs/001-key-value-separation.md for detailed design, API changes, and references.

---

**Related Work:**
- [WiscKey Paper (FAST'16)](https://www.usenix.org/system/files/conference/fast16/fast16-papers-lu.pdf)
- BadgerDB, RocksDB BlobDB, Titan, Pebble
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ben1009/mini-lsm/pull/71" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
