### PR TITLE
feat: add vLog core infrastructure for key-value separation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -496,6 +496,7 @@ dependencies = [
  "arc-swap",
  "bytes",
  "clap",
+ "crc32fast",
  "crossbeam-channel",
  "crossbeam-epoch",
  "crossbeam-skiplist",

--- a/mini-lsm-starter/Cargo.toml
+++ b/mini-lsm-starter/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 anyhow = "1"
 arc-swap = "1"
 bytes = "1"
+crc32fast = "1.3.2"
 clap = { version = "4.4.17", features = ["derive"] }
 crossbeam-channel = "0.5.15"
 crossbeam-epoch = "0.9"

--- a/mini-lsm-starter/src/lib.rs
+++ b/mini-lsm-starter/src/lib.rs
@@ -23,6 +23,7 @@ pub mod manifest;
 pub mod mem_table;
 pub mod mvcc;
 pub mod table;
+pub mod vlog;
 pub mod wal;
 
 #[cfg(test)]

--- a/mini-lsm-starter/src/vlog/builder.rs
+++ b/mini-lsm-starter/src/vlog/builder.rs
@@ -53,6 +53,16 @@ impl ValueLogWriter {
     ///
     /// Returns the total number of bytes written (header + key + value + padding).
     pub fn append(&mut self, key: &[u8], value: &[u8]) -> Result<usize> {
+        anyhow::ensure!(
+            key.len() <= u16::MAX as usize,
+            "key length {} exceeds u16 capacity",
+            key.len()
+        );
+        anyhow::ensure!(
+            value.len() <= u32::MAX as usize,
+            "value length {} exceeds u32 capacity",
+            value.len()
+        );
         let value_crc32 = crc32fast::hash(value);
 
         let entry_header = VlogEntryHeader {

--- a/mini-lsm-starter/src/vlog/builder.rs
+++ b/mini-lsm-starter/src/vlog/builder.rs
@@ -165,14 +165,8 @@ impl ValueLogBuilder {
             value.len(),
             self.options.max_value_size
         );
-        let entry_size = HEADER_SIZE
-            .checked_add(key.len())
-            .and_then(|s| s.checked_add(value.len()))
+        let total = VlogEntryHeader::compute_entry_size(key.len(), value.len())
             .context("entry size overflow")?;
-        let padding = (ALIGNMENT - (entry_size % ALIGNMENT)) % ALIGNMENT;
-        let total = entry_size
-            .checked_add(padding)
-            .context("total size overflow")?;
         anyhow::ensure!(
             total <= u32::MAX as usize,
             "vLog entry size {} exceeds u32 capacity",

--- a/mini-lsm-starter/src/vlog/builder.rs
+++ b/mini-lsm-starter/src/vlog/builder.rs
@@ -85,10 +85,15 @@ impl ValueLogWriter {
         let mut header_buf = Vec::with_capacity(HEADER_SIZE);
         final_header.encode(&mut header_buf);
 
-        // Compute alignment padding
-        let entry_size = HEADER_SIZE + key.len() + value.len();
+        // Compute alignment padding (overflow-safe)
+        let entry_size = HEADER_SIZE
+            .checked_add(key.len())
+            .and_then(|s| s.checked_add(value.len()))
+            .context("entry size overflow")?;
         let padding = (ALIGNMENT - (entry_size % ALIGNMENT)) % ALIGNMENT;
-        let total = entry_size + padding;
+        let total = entry_size
+            .checked_add(padding)
+            .context("total size overflow")?;
 
         // Write: header + key + value + padding
         self.file.write_all(&header_buf)?;
@@ -175,6 +180,17 @@ impl ValueLogBuilder {
             total <= u32::MAX as usize,
             "vLog entry size {} exceeds u32 capacity",
             total
+        );
+        let new_size = self
+            .writer
+            .size()
+            .checked_add(total as u64)
+            .context("file size overflow")?;
+        anyhow::ensure!(
+            new_size <= self.options.max_vlog_file_size as u64,
+            "vLog file size {} would exceed max_vlog_file_size {}",
+            new_size,
+            self.options.max_vlog_file_size
         );
 
         let written = self.writer.append(key, value)?;

--- a/mini-lsm-starter/src/vlog/builder.rs
+++ b/mini-lsm-starter/src/vlog/builder.rs
@@ -1,0 +1,190 @@
+use std::fs::{File, OpenOptions};
+use std::io::{BufWriter, Write};
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+
+use crate::vlog::{
+    ALIGNMENT, HEADER_SIZE, VLOG_MAGIC, ValuePointer, ValueSeparationOptions, VlogEntryHeader,
+    VlogFileHeader,
+};
+
+/// Low-level sequential writer for a single vLog file.
+///
+/// Writes entries one at a time, maintaining the current file offset and size.
+/// The file always starts with a 16-byte `VlogFileHeader`.
+pub struct ValueLogWriter {
+    file: BufWriter<File>,
+    offset: u64,
+    size: u64,
+    file_id: u32,
+}
+
+impl ValueLogWriter {
+    /// Create a new vLog file and write the 16-byte file header.
+    pub fn create(path: PathBuf, file_id: u32) -> Result<Self> {
+        let file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&path)
+            .with_context(|| format!("failed to create vLog file {:?}", path))?;
+
+        let mut writer = BufWriter::new(file);
+
+        // Write the 16-byte VlogFileHeader
+        let header = VlogFileHeader {
+            magic: VLOG_MAGIC,
+            version: 1,
+            reserved: [0u8; 10],
+        };
+        let mut header_buf = Vec::with_capacity(VlogFileHeader::SIZE);
+        header.encode(&mut header_buf);
+        writer.write_all(&header_buf)?;
+
+        Ok(Self {
+            file: writer,
+            offset: VlogFileHeader::SIZE as u64,
+            size: VlogFileHeader::SIZE as u64,
+            file_id,
+        })
+    }
+
+    /// Append a key-value entry to the vLog file.
+    ///
+    /// Returns the total number of bytes written (header + key + value + padding).
+    pub fn append(&mut self, key: &[u8], value: &[u8]) -> Result<usize> {
+        let value_crc32 = crc32fast::hash(value);
+
+        let entry_header = VlogEntryHeader {
+            header_crc32: 0, // placeholder, computed below
+            value_crc32,
+            value_len: value.len() as u32,
+            key_len: key.len() as u16,
+            flags: 0,
+            _padding: [0u8; 8],
+        };
+
+        let header_crc32 = entry_header.compute_header_crc(key);
+
+        let final_header = VlogEntryHeader {
+            header_crc32,
+            ..entry_header
+        };
+
+        // Serialize the header
+        let mut header_buf = Vec::with_capacity(HEADER_SIZE);
+        final_header.encode(&mut header_buf);
+
+        // Compute alignment padding
+        let entry_size = HEADER_SIZE + key.len() + value.len();
+        let padding = (ALIGNMENT - (entry_size % ALIGNMENT)) % ALIGNMENT;
+        let total = entry_size + padding;
+
+        // Write: header + key + value + padding
+        self.file.write_all(&header_buf)?;
+        self.file.write_all(key)?;
+        self.file.write_all(value)?;
+        if padding > 0 {
+            self.file.write_all(&[0u8; 8][..padding])?;
+        }
+
+        self.offset += total as u64;
+        self.size += total as u64;
+
+        Ok(total)
+    }
+
+    /// Current write offset within the file.
+    pub fn offset(&self) -> u64 {
+        self.offset
+    }
+
+    /// Total bytes written so far (equivalent to offset after the file header).
+    pub fn size(&self) -> u64 {
+        self.size
+    }
+
+    /// The file ID of this vLog file.
+    pub fn file_id(&self) -> u32 {
+        self.file_id
+    }
+
+    /// Flush all buffered data and sync to disk.
+    pub fn close(&mut self) -> Result<()> {
+        self.file.flush()?;
+        self.file.get_ref().sync_all()?;
+        Ok(())
+    }
+}
+
+/// Builder for constructing vLog entries during SST construction.
+///
+/// Owned by `SsTableBuilder`, this wraps a `ValueLogWriter` and validates
+/// entries before writing them.
+pub struct ValueLogBuilder {
+    writer: ValueLogWriter,
+    file_id: u32,
+    options: ValueSeparationOptions,
+}
+
+impl ValueLogBuilder {
+    /// Create a new `ValueLogBuilder` for the given file.
+    pub fn create(path: PathBuf, file_id: u32, options: ValueSeparationOptions) -> Result<Self> {
+        let writer = ValueLogWriter::create(path, file_id)?;
+        Ok(Self {
+            writer,
+            file_id,
+            options,
+        })
+    }
+
+    /// Add a key-value pair to the vLog. Returns a `ValuePointer`.
+    ///
+    /// Validates key and value sizes before writing. The on-disk entry is
+    /// padded to an 8-byte boundary, and the total size (including padding)
+    /// is recorded in the returned `ValuePointer`.
+    pub fn add(&mut self, key: &[u8], value: &[u8]) -> Result<ValuePointer> {
+        let offset = self.writer.offset();
+
+        // Validate before writing to avoid corrupting the vLog
+        anyhow::ensure!(
+            key.len() <= u16::MAX as usize,
+            "key length {} exceeds vLog header u16 capacity",
+            key.len()
+        );
+        anyhow::ensure!(
+            value.len() <= self.options.max_value_size,
+            "value length {} exceeds max_value_size {}",
+            value.len(),
+            self.options.max_value_size
+        );
+        let entry_size = HEADER_SIZE + key.len() + value.len();
+        let padding = (ALIGNMENT - (entry_size % ALIGNMENT)) % ALIGNMENT;
+        let total = entry_size + padding;
+        anyhow::ensure!(
+            total <= u32::MAX as usize,
+            "vLog entry size {} exceeds u32 capacity",
+            total
+        );
+
+        let written = self.writer.append(key, value)?;
+        debug_assert_eq!(written, total);
+        debug_assert_eq!(self.writer.offset() % ALIGNMENT as u64, 0);
+
+        Ok(ValuePointer {
+            file_id: self.file_id,
+            offset,
+            size: total as u32,
+        })
+    }
+
+    /// The file ID of this builder's vLog file.
+    pub fn file_id(&self) -> u32 {
+        self.file_id
+    }
+
+    /// Flush and sync the underlying file to disk.
+    pub fn close(&mut self) -> Result<()> {
+        self.writer.close()
+    }
+}

--- a/mini-lsm-starter/src/vlog/builder.rs
+++ b/mini-lsm-starter/src/vlog/builder.rs
@@ -119,7 +119,7 @@ impl ValueLogWriter {
     /// Flush all buffered data and sync to disk.
     pub fn close(&mut self) -> Result<()> {
         self.file.flush()?;
-        self.file.get_ref().sync_all()?;
+        self.file.get_ref().sync_data()?;
         Ok(())
     }
 }

--- a/mini-lsm-starter/src/vlog/builder.rs
+++ b/mini-lsm-starter/src/vlog/builder.rs
@@ -173,9 +173,14 @@ impl ValueLogBuilder {
             value.len(),
             self.options.max_value_size
         );
-        let entry_size = HEADER_SIZE + key.len() + value.len();
+        let entry_size = HEADER_SIZE
+            .checked_add(key.len())
+            .and_then(|s| s.checked_add(value.len()))
+            .context("entry size overflow")?;
         let padding = (ALIGNMENT - (entry_size % ALIGNMENT)) % ALIGNMENT;
-        let total = entry_size + padding;
+        let total = entry_size
+            .checked_add(padding)
+            .context("total size overflow")?;
         anyhow::ensure!(
             total <= u32::MAX as usize,
             "vLog entry size {} exceeds u32 capacity",

--- a/mini-lsm-starter/src/vlog/builder.rs
+++ b/mini-lsm-starter/src/vlog/builder.rs
@@ -79,9 +79,9 @@ impl ValueLogWriter {
             ..entry_header
         };
 
-        // Serialize the header
-        let mut header_buf = Vec::with_capacity(HEADER_SIZE);
-        final_header.encode(&mut header_buf);
+        // Serialize the header to a stack-allocated array
+        let mut header_buf = [0u8; HEADER_SIZE];
+        final_header.encode(&mut header_buf[..]);
 
         // Compute total entry size with alignment padding (overflow-safe)
         let total = VlogEntryHeader::compute_entry_size(key.len(), value.len())

--- a/mini-lsm-starter/src/vlog/builder.rs
+++ b/mini-lsm-starter/src/vlog/builder.rs
@@ -117,7 +117,7 @@ impl ValueLogWriter {
     }
 
     /// Flush all buffered data and sync to disk.
-    pub fn close(&mut self) -> Result<()> {
+    pub fn close(mut self) -> Result<()> {
         self.file.flush()?;
         self.file.get_ref().sync_data()?;
         Ok(())
@@ -190,7 +190,7 @@ impl ValueLogBuilder {
     }
 
     /// Flush and sync the underlying file to disk.
-    pub fn close(&mut self) -> Result<()> {
+    pub fn close(self) -> Result<()> {
         self.writer.close()
     }
 }

--- a/mini-lsm-starter/src/vlog/builder.rs
+++ b/mini-lsm-starter/src/vlog/builder.rs
@@ -16,7 +16,6 @@ use crate::vlog::{
 pub struct ValueLogWriter {
     file: BufWriter<File>,
     offset: u64,
-    size: u64,
     file_id: u32,
 }
 
@@ -37,14 +36,13 @@ impl ValueLogWriter {
             version: 1,
             reserved: [0u8; 10],
         };
-        let mut header_buf = Vec::with_capacity(VlogFileHeader::SIZE);
-        header.encode(&mut header_buf);
+        let mut header_buf = [0u8; VlogFileHeader::SIZE];
+        header.encode(&mut header_buf[..]);
         writer.write_all(&header_buf)?;
 
         Ok(Self {
             file: writer,
             offset: VlogFileHeader::SIZE as u64,
-            size: VlogFileHeader::SIZE as u64,
             file_id,
         })
     }
@@ -85,15 +83,10 @@ impl ValueLogWriter {
         let mut header_buf = Vec::with_capacity(HEADER_SIZE);
         final_header.encode(&mut header_buf);
 
-        // Compute alignment padding (overflow-safe)
-        let entry_size = HEADER_SIZE
-            .checked_add(key.len())
-            .and_then(|s| s.checked_add(value.len()))
+        // Compute total entry size with alignment padding (overflow-safe)
+        let total = VlogEntryHeader::compute_entry_size(key.len(), value.len())
             .context("entry size overflow")?;
-        let padding = (ALIGNMENT - (entry_size % ALIGNMENT)) % ALIGNMENT;
-        let total = entry_size
-            .checked_add(padding)
-            .context("total size overflow")?;
+        let padding = total - HEADER_SIZE - key.len() - value.len();
 
         // Write: header + key + value + padding
         self.file.write_all(&header_buf)?;
@@ -104,7 +97,6 @@ impl ValueLogWriter {
         }
 
         self.offset += total as u64;
-        self.size += total as u64;
 
         Ok(total)
     }
@@ -116,7 +108,7 @@ impl ValueLogWriter {
 
     /// Total bytes written so far (equivalent to offset after the file header).
     pub fn size(&self) -> u64 {
-        self.size
+        self.offset
     }
 
     /// The file ID of this vLog file.

--- a/mini-lsm-starter/src/vlog/builder.rs
+++ b/mini-lsm-starter/src/vlog/builder.rs
@@ -172,17 +172,6 @@ impl ValueLogBuilder {
             "vLog entry size {} exceeds u32 capacity",
             total
         );
-        let new_size = self
-            .writer
-            .size()
-            .checked_add(total as u64)
-            .context("file size overflow")?;
-        anyhow::ensure!(
-            new_size <= self.options.max_vlog_file_size as u64,
-            "vLog file size {} would exceed max_vlog_file_size {}",
-            new_size,
-            self.options.max_vlog_file_size
-        );
 
         let written = self.writer.append(key, value)?;
         debug_assert_eq!(written, total);

--- a/mini-lsm-starter/src/vlog/mod.rs
+++ b/mini-lsm-starter/src/vlog/mod.rs
@@ -517,7 +517,7 @@ mod tests {
         // Iterate headers
         let reader = ValueLogReader::open(path).unwrap();
         let iter = reader.iter_headers().unwrap().with_file_id(file_id);
-        let meta_list: Vec<_> = iter.collect();
+        let meta_list: Vec<_> = iter.map(|r| r.unwrap()).collect();
 
         assert_eq!(meta_list.len(), entries.len());
         for (i, meta) in meta_list.iter().enumerate() {

--- a/mini-lsm-starter/src/vlog/mod.rs
+++ b/mini-lsm-starter/src/vlog/mod.rs
@@ -164,6 +164,7 @@ impl VlogFileHeader {
             return Err(anyhow!("VlogFileHeader magic mismatch: 0x{:08X}", magic));
         }
         let version = buf.get_u16_le();
+        anyhow::ensure!(version == 1, "unsupported vLog version: {}", version);
         let mut reserved = [0u8; 10];
         buf.copy_to_slice(&mut reserved);
         Ok(Self {

--- a/mini-lsm-starter/src/vlog/mod.rs
+++ b/mini-lsm-starter/src/vlog/mod.rs
@@ -1,0 +1,604 @@
+pub mod builder;
+pub mod reader;
+
+pub use builder::ValueLogBuilder;
+pub use reader::{ValueLogReader, VlogEntryMeta};
+
+use anyhow::{Result, anyhow};
+use bytes::{Buf, BufMut};
+
+/// Magic number for vLog file header
+const VLOG_MAGIC: u32 = 0x564C4F47; // "VLOG"
+
+/// Per-entry header size (24 bytes)
+const HEADER_SIZE: usize = 24;
+
+/// Alignment boundary for vLog entries
+const ALIGNMENT: usize = 8;
+
+/// Magic tag byte that prefixes every encoded `ValuePointer`.
+/// Retained as a cheap corruption/desync detector alongside KvKind.
+const VALUE_POINTER_TAG: u8 = 0xFF;
+
+/// Per-entry value-kind stored with every key-value entry: in the memtable, WAL,
+/// and SST block metadata. This is the authoritative source of truth for
+/// distinguishing inline values from vLog pointers.
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum KvKind {
+    /// The value is stored inline in the SST block.
+    Inline = 0,
+    /// The value is a 17-byte encoded `ValuePointer` that references the vLog.
+    ValuePointer = 1,
+}
+
+impl KvKind {
+    pub fn from_u8(v: u8) -> Option<Self> {
+        match v {
+            0 => Some(Self::Inline),
+            1 => Some(Self::ValuePointer),
+            _ => None,
+        }
+    }
+}
+
+/// A pointer to a value stored in the Value Log.
+/// Stored inline in the LSM tree instead of the actual value.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ValuePointer {
+    /// Value log file ID
+    pub file_id: u32,
+    /// Offset within the file where the value starts
+    pub offset: u64,
+    /// Total size of the encoded entry on disk (header + key + value + padding).
+    pub size: u32,
+}
+
+impl ValuePointer {
+    /// Encode to bytes for storage in LSM tree.
+    /// Layout (17 bytes): `[tag:1][file_id:4][offset:8][size:4]`
+    pub fn encode(&self, buf: &mut Vec<u8>) {
+        buf.put_u8(VALUE_POINTER_TAG);
+        buf.put_u32_le(self.file_id);
+        buf.put_u64_le(self.offset);
+        buf.put_u32_le(self.size);
+    }
+
+    /// Decode from bytes. Returns an error if the buffer is malformed.
+    pub fn decode(mut buf: &[u8]) -> Result<Self> {
+        if buf.len() < Self::encoded_size() {
+            return Err(anyhow!(
+                "ValuePointer buffer too short: {} < {}",
+                buf.len(),
+                Self::encoded_size()
+            ));
+        }
+        let tag = buf.get_u8();
+        if tag != VALUE_POINTER_TAG {
+            return Err(anyhow!(
+                "ValuePointer tag mismatch: expected 0x{:02X}, got 0x{:02X}",
+                VALUE_POINTER_TAG,
+                tag
+            ));
+        }
+        Ok(Self {
+            file_id: buf.get_u32_le(),
+            offset: buf.get_u64_le(),
+            size: buf.get_u32_le(),
+        })
+    }
+
+    /// Try to decode from bytes. Returns `None` if the buffer is too short or
+    /// does not start with the `VALUE_POINTER_TAG` byte.
+    pub fn try_decode(buf: &[u8]) -> Option<Self> {
+        if buf.len() < Self::encoded_size() || buf[0] != VALUE_POINTER_TAG {
+            return None;
+        }
+        let mut b = &buf[1..];
+        Some(Self {
+            file_id: b.get_u32_le(),
+            offset: b.get_u64_le(),
+            size: b.get_u32_le(),
+        })
+    }
+
+    /// Total encoded size: 17 bytes (1-byte tag + 4 + 8 + 4)
+    pub const fn encoded_size() -> usize {
+        1 + 4 + 8 + 4
+    }
+}
+
+/// Configuration options for key-value separation.
+#[derive(Clone, Debug)]
+pub struct ValueSeparationOptions {
+    /// Enable key-value separation
+    pub enabled: bool,
+    /// Minimum value size to trigger separation (bytes)
+    pub min_value_size: usize,
+    /// Maximum size of a single value (bytes)
+    pub max_value_size: usize,
+    /// Maximum size of a single vLog file
+    pub max_vlog_file_size: usize,
+    /// Ratio of stale data to trigger garbage collection
+    pub gc_threshold_ratio: f64,
+    /// Maximum number of vLog files to keep open
+    pub max_open_vlog_files: usize,
+}
+
+impl Default for ValueSeparationOptions {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            min_value_size: 1024,
+            max_value_size: 128 << 20,
+            max_vlog_file_size: 64 << 20,
+            gc_threshold_ratio: 0.5,
+            max_open_vlog_files: 64,
+        }
+    }
+}
+
+/// Value log file header (first 16 bytes of each vLog file).
+/// Serialized/deserialized field-by-field with explicit little-endian encoding.
+pub struct VlogFileHeader {
+    pub magic: u32,
+    pub version: u16,
+    pub reserved: [u8; 10],
+}
+
+impl VlogFileHeader {
+    pub const SIZE: usize = 16;
+
+    pub fn encode(&self, buf: &mut Vec<u8>) {
+        buf.put_u32_le(self.magic);
+        buf.put_u16_le(self.version);
+        buf.extend_from_slice(&self.reserved);
+    }
+
+    pub fn decode(mut buf: &[u8]) -> Result<Self> {
+        if buf.len() < Self::SIZE {
+            return Err(anyhow!("VlogFileHeader too short"));
+        }
+        let magic = buf.get_u32_le();
+        if magic != VLOG_MAGIC {
+            return Err(anyhow!("VlogFileHeader magic mismatch: 0x{:08X}", magic));
+        }
+        let version = buf.get_u16_le();
+        let mut reserved = [0u8; 10];
+        buf.copy_to_slice(&mut reserved);
+        Ok(Self {
+            magic,
+            version,
+            reserved,
+        })
+    }
+}
+
+/// Entry header (precedes each key-value pair in the vLog).
+/// Always exactly 24 bytes. Serialized field-by-field.
+pub struct VlogEntryHeader {
+    pub header_crc32: u32,
+    pub value_crc32: u32,
+    pub value_len: u32,
+    pub key_len: u16,
+    pub flags: u16,
+    pub _padding: [u8; 8],
+}
+
+impl VlogEntryHeader {
+    pub const fn size() -> usize {
+        HEADER_SIZE
+    }
+
+    /// Serialize the header to bytes (24 bytes, little-endian).
+    pub fn encode(&self, buf: &mut Vec<u8>) {
+        buf.put_u32_le(self.header_crc32);
+        buf.put_u32_le(self.value_crc32);
+        buf.put_u32_le(self.value_len);
+        buf.put_u16_le(self.key_len);
+        buf.put_u16_le(self.flags);
+        buf.extend_from_slice(&self._padding);
+    }
+
+    /// Compute the CRC32 over (header_without_header_crc + key_bytes).
+    /// The header_crc32 field itself is excluded from the CRC.
+    pub fn compute_header_crc(&self, key: &[u8]) -> u32 {
+        let mut hasher = crc32fast::Hasher::new();
+        hasher.update(&self.value_crc32.to_le_bytes());
+        hasher.update(&self.value_len.to_le_bytes());
+        hasher.update(&self.key_len.to_le_bytes());
+        hasher.update(&self.flags.to_le_bytes());
+        hasher.update(&self._padding);
+        hasher.update(key);
+        hasher.finalize()
+    }
+}
+
+/// A single entry read from a vLog file.
+pub struct VlogEntry {
+    pub ptr: ValuePointer,
+    pub key: Vec<u8>,
+    pub value: Vec<u8>,
+    pub size: usize,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::vlog::builder::ValueLogWriter;
+    use crate::vlog::reader::ValueLogReader;
+
+    // ---------------------------------------------------------------
+    // 1. ValuePointer encode/decode round-trip
+    // ---------------------------------------------------------------
+    #[test]
+    fn test_value_pointer_encode_decode() {
+        let cases = [
+            ValuePointer {
+                file_id: 0,
+                offset: 0,
+                size: 0,
+            },
+            ValuePointer {
+                file_id: 42,
+                offset: 1024,
+                size: 256,
+            },
+            ValuePointer {
+                file_id: u32::MAX,
+                offset: u64::MAX,
+                size: u32::MAX,
+            },
+        ];
+
+        for ptr in &cases {
+            let mut buf = Vec::new();
+            ptr.encode(&mut buf);
+            assert_eq!(buf.len(), ValuePointer::encoded_size());
+            assert_eq!(buf.len(), 17);
+            assert_eq!(buf[0], VALUE_POINTER_TAG);
+
+            let decoded = ValuePointer::decode(&buf).unwrap();
+            assert_eq!(*ptr, decoded);
+
+            // Extra trailing bytes should be ignored.
+            let mut extended = buf.clone();
+            extended.extend_from_slice(&[0xAB; 32]);
+            let decoded2 = ValuePointer::decode(&extended).unwrap();
+            assert_eq!(*ptr, decoded2);
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // 2. ValuePointer try_decode edge cases
+    // ---------------------------------------------------------------
+    #[test]
+    fn test_value_pointer_try_decode() {
+        let ptr = ValuePointer {
+            file_id: 7,
+            offset: 999,
+            size: 128,
+        };
+        let mut buf = Vec::new();
+        ptr.encode(&mut buf);
+
+        // Valid data
+        assert_eq!(ValuePointer::try_decode(&buf), Some(ptr));
+
+        // Short buffer (< 17 bytes)
+        for len in 0..ValuePointer::encoded_size() {
+            assert_eq!(ValuePointer::try_decode(&buf[..len]), None);
+        }
+
+        // Correct length but wrong tag byte
+        let mut bad_tag = buf.clone();
+        bad_tag[0] = 0x00;
+        assert_eq!(ValuePointer::try_decode(&bad_tag), None);
+
+        let mut bad_tag2 = buf.clone();
+        bad_tag2[0] = 0xFE;
+        assert_eq!(ValuePointer::try_decode(&bad_tag2), None);
+    }
+
+    // ---------------------------------------------------------------
+    // 3. KvKind::from_u8
+    // ---------------------------------------------------------------
+    #[test]
+    fn test_kv_kind_from_u8() {
+        assert_eq!(KvKind::from_u8(0), Some(KvKind::Inline));
+        assert_eq!(KvKind::from_u8(1), Some(KvKind::ValuePointer));
+
+        for v in [2u8, 3, 100, 254, 255] {
+            assert_eq!(
+                KvKind::from_u8(v),
+                None,
+                "KvKind::from_u8({v}) should be None"
+            );
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // 4. VlogEntryHeader::compute_header_crc determinism + coverage
+    // ---------------------------------------------------------------
+    #[test]
+    fn test_vlog_entry_header_crc() {
+        let key = b"test_key_for_crc";
+
+        let hdr = VlogEntryHeader {
+            header_crc32: 0,
+            value_crc32: 0xDEADBEEF,
+            value_len: 4096,
+            key_len: 16,
+            flags: 1,
+            _padding: [0xAA; 8],
+        };
+        let crc1 = hdr.compute_header_crc(key);
+
+        // Deterministic: same inputs produce same CRC.
+        let crc2 = hdr.compute_header_crc(key);
+        assert_eq!(crc1, crc2);
+
+        // Different key -> different CRC.
+        let crc_different_key = hdr.compute_header_crc(b"other_key");
+        assert_ne!(crc1, crc_different_key);
+
+        // Changing each covered field must change the CRC.
+        let h = VlogEntryHeader {
+            value_crc32: 0xDEADBEEF ^ 1,
+            ..hdr
+        };
+        assert_ne!(h.compute_header_crc(key), crc1);
+
+        let h = VlogEntryHeader {
+            value_len: 4096 ^ 1,
+            ..hdr
+        };
+        assert_ne!(h.compute_header_crc(key), crc1);
+
+        let h = VlogEntryHeader {
+            key_len: 16 ^ 1,
+            ..hdr
+        };
+        assert_ne!(h.compute_header_crc(key), crc1);
+
+        let h = VlogEntryHeader {
+            flags: 1 ^ 1,
+            ..hdr
+        };
+        assert_ne!(h.compute_header_crc(key), crc1);
+
+        let mut different_padding = [0xAA; 8];
+        different_padding[0] ^= 0xFF;
+        let h = VlogEntryHeader {
+            _padding: different_padding,
+            ..hdr
+        };
+        assert_ne!(h.compute_header_crc(key), crc1);
+
+        // header_crc32 itself is excluded from the CRC computation.
+        let h = VlogEntryHeader {
+            header_crc32: 0x12345678,
+            ..hdr
+        };
+        assert_eq!(h.compute_header_crc(key), crc1);
+    }
+
+    // ---------------------------------------------------------------
+    // 5. Write + read round-trip using ValueLogWriter / ValueLogReader
+    // ---------------------------------------------------------------
+    #[test]
+    fn test_vlog_write_read_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("00001.vlog");
+        let file_id = 1u32;
+
+        let entries: Vec<(&[u8], &[u8])> = vec![
+            (b"key1", b"value1"),
+            (b"key2", b"value2_value2"),
+            (b"longer_key_name", b"short"),
+            (b"k", b"another_value_here"),
+        ];
+
+        // Write entries with ValueLogWriter
+        let mut writer = ValueLogWriter::create(path.clone(), file_id).unwrap();
+        let mut pointers = Vec::new();
+        for (k, v) in &entries {
+            let offset = writer.offset();
+            let total = writer.append(k, v).unwrap();
+            pointers.push(ValuePointer {
+                file_id,
+                offset,
+                size: total as u32,
+            });
+        }
+        writer.close().unwrap();
+
+        // Read back with ValueLogReader
+        let reader = ValueLogReader::open(path).unwrap();
+        for (i, (expected_key, expected_value)) in entries.iter().enumerate() {
+            let entry = reader
+                .read_entry(pointers[i].offset, pointers[i].size)
+                .unwrap();
+            assert_eq!(entry.key, *expected_key);
+            assert_eq!(entry.value, *expected_value);
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // 6. 8-byte alignment (using ValueLogWriter)
+    // ---------------------------------------------------------------
+    #[test]
+    fn test_vlog_alignment() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("align.vlog");
+
+        let mut writer = ValueLogWriter::create(path, 0).unwrap();
+
+        // After the 16-byte file header, the writer offset starts at 16.
+        assert_eq!(writer.offset() as usize % ALIGNMENT, 0);
+
+        let test_cases: Vec<(&[u8], &[u8])> = vec![
+            (b"k1", b"v"),         // 24 + 2 + 1 = 27 -> pad to 32
+            (b"key2", b"value"),   // 24 + 4 + 6 = 34 -> pad to 40
+            (b"k", b"0123456789"), // 24 + 1 + 10 = 35 -> pad to 40
+        ];
+
+        for (key, value) in &test_cases {
+            let total = writer.append(key, value).unwrap();
+
+            // Total must be a multiple of 8.
+            assert_eq!(
+                total % ALIGNMENT,
+                0,
+                "entry for key={:?} wrote {} bytes, not 8-byte aligned",
+                key,
+                total
+            );
+
+            // Writer offset must remain 8-byte aligned.
+            assert_eq!(writer.offset() as usize % ALIGNMENT, 0);
+
+            // Verify the written size matches expected padding.
+            let expected_raw = HEADER_SIZE + key.len() + value.len();
+            let expected_pad = (ALIGNMENT - (expected_raw % ALIGNMENT)) % ALIGNMENT;
+            assert_eq!(total, expected_raw + expected_pad);
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // 7. Large entry (10 KB value)
+    // ---------------------------------------------------------------
+    #[test]
+    fn test_vlog_large_entry() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("large.vlog");
+        let file_id = 5u32;
+
+        let key = b"big";
+        let value = vec![0xAB_u8; 10 * 1024];
+
+        let mut writer = ValueLogWriter::create(path.clone(), file_id).unwrap();
+        let offset = writer.offset();
+        let total = writer.append(key, &value).unwrap();
+        writer.close().unwrap();
+
+        let reader = ValueLogReader::open(path).unwrap();
+        let entry = reader.read_entry(offset, total as u32).unwrap();
+
+        assert_eq!(entry.key, key);
+        assert_eq!(entry.value.len(), 10 * 1024);
+        assert!(entry.value.iter().all(|&b| b == 0xAB));
+        assert_eq!(entry.ptr.size as usize, entry.size);
+        assert_eq!(entry.size % ALIGNMENT, 0);
+    }
+
+    // ---------------------------------------------------------------
+    // 8. Header-only iterator via iter_headers()
+    // ---------------------------------------------------------------
+    #[test]
+    fn test_vlog_header_iterator() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("iter.vlog");
+        let file_id = 3u32;
+
+        let entries: Vec<(&[u8], &[u8])> =
+            vec![(b"alpha", b"aaa"), (b"beta", b"bbbbbb"), (b"gamma", b"g")];
+
+        // Write entries
+        let mut writer = ValueLogWriter::create(path.clone(), file_id).unwrap();
+        let mut expected_meta = Vec::new();
+        for (k, v) in &entries {
+            let offset = writer.offset();
+            let total = writer.append(k, v).unwrap();
+            expected_meta.push((k.to_vec(), total, offset));
+        }
+        writer.close().unwrap();
+
+        // Iterate headers
+        let reader = ValueLogReader::open(path).unwrap();
+        let iter = reader.iter_headers().unwrap().with_file_id(file_id);
+        let meta_list: Vec<_> = iter.collect();
+
+        assert_eq!(meta_list.len(), entries.len());
+        for (i, meta) in meta_list.iter().enumerate() {
+            assert_eq!(meta.key, entries[i].0, "key mismatch at index {i}");
+            assert_eq!(
+                meta.ptr.offset, expected_meta[i].2,
+                "offset mismatch at index {i}"
+            );
+            assert_eq!(
+                meta.entry_size, expected_meta[i].1,
+                "size mismatch at index {i}"
+            );
+            assert_eq!(
+                meta.value_len,
+                entries[i].1.len() as u32,
+                "value_len mismatch at index {i}"
+            );
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // 9. CRC mutation detection
+    // ---------------------------------------------------------------
+    #[test]
+    fn test_vlog_crc_mutation() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("crc_mut.vlog");
+        let file_id = 9u32;
+
+        let key = b"crc_test";
+        let value = b"original_value";
+
+        // Write one entry.
+        let mut writer = ValueLogWriter::create(path.clone(), file_id).unwrap();
+        let offset = writer.offset();
+        let total = writer.append(key, value).unwrap();
+        writer.close().unwrap();
+
+        // Read should succeed before corruption.
+        let reader = ValueLogReader::open(path.clone()).unwrap();
+        reader
+            .read_entry(offset, total as u32)
+            .expect("read should succeed on clean data");
+
+        // Corrupt a byte in the value region on disk.
+        // On-disk layout: [file_hdr(16)] [entry_hdr(24)] [key(8)] [value(14)] [padding]
+        // Value starts at 16 + 24 + 8 = 48.
+        let mut raw = std::fs::read(&path).unwrap();
+        let value_start = VlogFileHeader::SIZE + HEADER_SIZE + key.len();
+        assert_eq!(raw[value_start], value[0]);
+        raw[value_start] ^= 0xFF;
+        std::fs::write(&path, &raw).unwrap();
+
+        // Header CRC is still valid (it covers key, not value),
+        // but value CRC must fail.
+        let reader = ValueLogReader::open(path.clone()).unwrap();
+        let err = match reader.read_entry(offset, total as u32) {
+            Ok(_) => panic!("expected CRC failure after value corruption"),
+            Err(e) => e,
+        };
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("value CRC") || msg.contains("value crc"),
+            "expected value CRC error, got: {msg}"
+        );
+
+        // Restore value byte, corrupt the key instead.
+        raw[value_start] ^= 0xFF;
+        let key_start = VlogFileHeader::SIZE + HEADER_SIZE;
+        raw[key_start] ^= 0xFF;
+        std::fs::write(&path, &raw).unwrap();
+
+        let reader = ValueLogReader::open(path).unwrap();
+        let err = match reader.read_entry(offset, total as u32) {
+            Ok(_) => panic!("expected CRC failure after key corruption"),
+            Err(e) => e,
+        };
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("header CRC") || msg.contains("header crc"),
+            "expected header CRC error, got: {msg}"
+        );
+    }
+}

--- a/mini-lsm-starter/src/vlog/mod.rs
+++ b/mini-lsm-starter/src/vlog/mod.rs
@@ -57,7 +57,7 @@ pub struct ValuePointer {
 impl ValuePointer {
     /// Encode to bytes for storage in LSM tree.
     /// Layout (17 bytes): `[tag:1][file_id:4][offset:8][size:4]`
-    pub fn encode(&self, buf: &mut Vec<u8>) {
+    pub fn encode(&self, mut buf: impl BufMut) {
         buf.put_u8(VALUE_POINTER_TAG);
         buf.put_u32_le(self.file_id);
         buf.put_u64_le(self.offset);
@@ -149,10 +149,10 @@ pub struct VlogFileHeader {
 impl VlogFileHeader {
     pub const SIZE: usize = 16;
 
-    pub fn encode(&self, buf: &mut Vec<u8>) {
+    pub fn encode(&self, mut buf: impl BufMut) {
         buf.put_u32_le(self.magic);
         buf.put_u16_le(self.version);
-        buf.extend_from_slice(&self.reserved);
+        buf.put_slice(&self.reserved);
     }
 
     pub fn decode(mut buf: &[u8]) -> Result<Self> {
@@ -191,13 +191,20 @@ impl VlogEntryHeader {
     }
 
     /// Serialize the header to bytes (24 bytes, little-endian).
-    pub fn encode(&self, buf: &mut Vec<u8>) {
+    pub fn encode(&self, mut buf: impl BufMut) {
         buf.put_u32_le(self.header_crc32);
         buf.put_u32_le(self.value_crc32);
         buf.put_u32_le(self.value_len);
         buf.put_u16_le(self.key_len);
         buf.put_u16_le(self.flags);
-        buf.extend_from_slice(&self._padding);
+        buf.put_slice(&self._padding);
+    }
+
+    /// Compute the total entry size including header, key, value, and alignment padding.
+    pub fn compute_entry_size(key_len: usize, value_len: usize) -> Option<usize> {
+        let entry_size = HEADER_SIZE.checked_add(key_len)?.checked_add(value_len)?;
+        let padding = (ALIGNMENT - (entry_size % ALIGNMENT)) % ALIGNMENT;
+        entry_size.checked_add(padding)
     }
 
     /// Compute the CRC32 over (header_without_header_crc + key_bytes).

--- a/mini-lsm-starter/src/vlog/reader.rs
+++ b/mini-lsm-starter/src/vlog/reader.rs
@@ -6,7 +6,7 @@ use std::sync::Mutex;
 use anyhow::{Result, anyhow};
 use bytes::Buf;
 
-use super::{ALIGNMENT, HEADER_SIZE, ValuePointer, VlogEntry, VlogFileHeader};
+use super::{ALIGNMENT, HEADER_SIZE, ValuePointer, VlogEntry, VlogEntryHeader, VlogFileHeader};
 
 /// Lightweight header-only entry metadata for GC analysis.
 /// Contains the pointer, key, and value length without reading the value payload.
@@ -59,6 +59,15 @@ impl ValueLogReader {
             HEADER_SIZE
         );
 
+        let file_len = file.metadata()?.len();
+        anyhow::ensure!(
+            offset + size as u64 <= file_len,
+            "entry offset {} and size {} exceeds file length {}",
+            offset,
+            size,
+            file_len
+        );
+
         let mut buf = vec![0u8; size];
         file.read_exact(&mut buf)?;
 
@@ -75,30 +84,33 @@ impl ValueLogReader {
         let mut padding = [0u8; 8];
         hdr_bytes.copy_to_slice(&mut padding);
 
-        // Bounds check
+        // Bounds check (overflow-safe)
         anyhow::ensure!(
-            HEADER_SIZE + key_len + value_len <= size,
-            "entry data (header {} + key {} + value {}) exceeds entry size {}",
-            HEADER_SIZE,
+            key_len <= size - HEADER_SIZE,
+            "key length {} exceeds remaining entry size {}",
             key_len,
+            size - HEADER_SIZE
+        );
+        anyhow::ensure!(
+            value_len <= size - HEADER_SIZE - key_len,
+            "value length {} exceeds remaining entry size {}",
             value_len,
-            size
+            size - HEADER_SIZE - key_len
         );
 
         let key = buf[HEADER_SIZE..HEADER_SIZE + key_len].to_vec();
         let value = buf[HEADER_SIZE + key_len..HEADER_SIZE + key_len + value_len].to_vec();
 
         // Validate header CRC32: covers value_crc32 + value_len + key_len + flags + padding + key
-        let computed_header_crc = {
-            let mut hasher = crc32fast::Hasher::new();
-            hasher.update(&value_crc32.to_le_bytes());
-            hasher.update(&(value_len as u32).to_le_bytes());
-            hasher.update(&(key_len as u16).to_le_bytes());
-            hasher.update(&flags.to_le_bytes());
-            hasher.update(&padding);
-            hasher.update(&key);
-            hasher.finalize()
+        let entry_header = VlogEntryHeader {
+            header_crc32,
+            value_crc32,
+            value_len: value_len as u32,
+            key_len: key_len as u16,
+            flags,
+            _padding: padding,
         };
+        let computed_header_crc = entry_header.compute_header_crc(&key);
         anyhow::ensure!(
             computed_header_crc == header_crc32,
             "header CRC32 mismatch: computed 0x{:08X}, stored 0x{:08X} at offset {}",
@@ -165,7 +177,7 @@ impl VlogHeaderIterator {
 }
 
 impl Iterator for VlogHeaderIterator {
-    type Item = VlogEntryMeta;
+    type Item = Result<VlogEntryMeta>;
 
     fn next(&mut self) -> Option<Self::Item> {
         // Stop at EOF
@@ -173,54 +185,70 @@ impl Iterator for VlogHeaderIterator {
             return None;
         }
 
-        // Read the 24-byte entry header
-        let mut hdr_buf = [0u8; HEADER_SIZE];
-        if self.reader.seek(SeekFrom::Start(self.offset)).is_err() {
-            return None;
-        }
-        if self.reader.read_exact(&mut hdr_buf).is_err() {
-            return None;
-        }
+        let result = (|| -> Result<VlogEntryMeta> {
+            // Read the 24-byte entry header
+            let mut hdr_buf = [0u8; HEADER_SIZE];
+            self.reader.seek(SeekFrom::Start(self.offset))?;
+            self.reader.read_exact(&mut hdr_buf)?;
 
-        let mut hdr_bytes: &[u8] = &hdr_buf;
-        let _header_crc32 = hdr_bytes.get_u32_le();
-        let _value_crc32 = hdr_bytes.get_u32_le();
-        let value_len = hdr_bytes.get_u32_le();
-        let key_len = hdr_bytes.get_u16_le() as usize;
-        let _flags = hdr_bytes.get_u16_le();
-        let _padding = hdr_bytes.get_u64_le(); // 8 bytes
+            let mut hdr_bytes: &[u8] = &hdr_buf;
+            let header_crc32 = hdr_bytes.get_u32_le();
+            let value_crc32 = hdr_bytes.get_u32_le();
+            let value_len = hdr_bytes.get_u32_le();
+            let key_len = hdr_bytes.get_u16_le() as usize;
+            let flags = hdr_bytes.get_u16_le();
+            let mut padding = [0u8; 8];
+            hdr_bytes.copy_to_slice(&mut padding);
 
-        // Compute total entry size with alignment padding
-        let raw_size = HEADER_SIZE + key_len + value_len as usize;
-        let entry_size = raw_size.div_ceil(ALIGNMENT) * ALIGNMENT;
+            // Compute total entry size with alignment padding
+            let raw_size = HEADER_SIZE as u64 + key_len as u64 + value_len as u64;
+            let entry_size = raw_size.div_ceil(ALIGNMENT as u64) * ALIGNMENT as u64;
 
-        // Sanity check: entry must not extend past EOF
-        if self.offset + entry_size as u64 > self.file_size {
-            return None;
-        }
+            anyhow::ensure!(entry_size <= u32::MAX as u64, "entry size exceeds u32::MAX");
+            anyhow::ensure!(
+                self.offset + entry_size <= self.file_size,
+                "entry extends past EOF"
+            );
 
-        // Read only the key bytes (skip the value payload for efficiency)
-        let key_start = self.offset + HEADER_SIZE as u64;
-        if self.reader.seek(SeekFrom::Start(key_start)).is_err() {
-            return None;
-        }
-        let mut key = vec![0u8; key_len];
-        if self.reader.read_exact(&mut key).is_err() {
-            return None;
-        }
+            // Read only the key bytes (skip the value payload for efficiency)
+            let key_start = self.offset + HEADER_SIZE as u64;
+            self.reader.seek(SeekFrom::Start(key_start))?;
+            let mut key = vec![0u8; key_len];
+            self.reader.read_exact(&mut key)?;
 
-        let current_offset = self.offset;
-        self.offset += entry_size as u64;
+            // Validate header CRC32
+            let entry_header = VlogEntryHeader {
+                header_crc32,
+                value_crc32,
+                value_len,
+                key_len: key_len as u16,
+                flags,
+                _padding: padding,
+            };
+            let computed_header_crc = entry_header.compute_header_crc(&key);
+            anyhow::ensure!(
+                computed_header_crc == header_crc32,
+                "header CRC32 mismatch: computed 0x{:08X}, stored 0x{:08X} at offset {}",
+                computed_header_crc,
+                header_crc32,
+                self.offset
+            );
 
-        Some(VlogEntryMeta {
-            ptr: ValuePointer {
-                file_id: self.file_id,
-                offset: current_offset,
-                size: entry_size as u32,
-            },
-            key,
-            value_len,
-            entry_size,
-        })
+            let current_offset = self.offset;
+            self.offset += entry_size;
+
+            Ok(VlogEntryMeta {
+                ptr: ValuePointer {
+                    file_id: self.file_id,
+                    offset: current_offset,
+                    size: entry_size as u32,
+                },
+                key,
+                value_len,
+                entry_size: entry_size as usize,
+            })
+        })();
+
+        Some(result)
     }
 }

--- a/mini-lsm-starter/src/vlog/reader.rs
+++ b/mini-lsm-starter/src/vlog/reader.rs
@@ -88,18 +88,9 @@ impl ValueLogReader {
             size
         );
 
-        // Guard against OOM from corrupted headers: ensure the entry fits
-        // within the actual physical file before allocating key/value vectors.
-        let file_len = self.file.metadata()?.len();
-        let end_offset = offset
-            .checked_add(expected_size as u64)
-            .ok_or_else(|| anyhow!("offset overflow"))?;
-        anyhow::ensure!(
-            end_offset <= file_len,
-            "entry end offset {} exceeds file length {}",
-            end_offset,
-            file_len
-        );
+        // OOM safety: `size` originates from the trusted LSM index/manifest,
+        // and `size == expected_size` above catches header corruption.
+        // `read_exact_at` will fail with `UnexpectedEof` if the entry is past EOF.
 
         // Read key and value directly into their destination vectors to avoid
         // copying large payloads through an intermediate buffer.

--- a/mini-lsm-starter/src/vlog/reader.rs
+++ b/mini-lsm-starter/src/vlog/reader.rs
@@ -67,28 +67,40 @@ impl ValueLogReader {
         let mut padding = [0u8; 8];
         hdr_bytes.copy_to_slice(&mut padding);
 
-        // Bounds check (overflow-safe)
+        // Validate that the caller-supplied size matches the expected aligned entry size
+        let expected_size = VlogEntryHeader::compute_entry_size(key_len, value_len)
+            .ok_or_else(|| anyhow!("entry size overflow"))?;
         anyhow::ensure!(
-            key_len <= size - HEADER_SIZE,
-            "key length {} exceeds remaining entry size {}",
-            key_len,
-            size - HEADER_SIZE
-        );
-        anyhow::ensure!(
-            value_len <= size - HEADER_SIZE - key_len,
-            "value length {} exceeds remaining entry size {}",
-            value_len,
-            size - HEADER_SIZE - key_len
+            size == expected_size,
+            "entry size mismatch: expected {}, got {}",
+            expected_size,
+            size
         );
 
         // Read key and value directly into their destination vectors.
         let mut key = vec![0u8; key_len];
         self.file
-            .read_exact_at(&mut key, offset + HEADER_SIZE as u64)?;
+            .read_exact_at(&mut key, offset + HEADER_SIZE as u64)
+            .map_err(|e| {
+                anyhow!(
+                    "failed to read key at offset {} from {:?}: {}",
+                    offset + HEADER_SIZE as u64,
+                    self.path,
+                    e
+                )
+            })?;
 
         let mut value = vec![0u8; value_len];
         self.file
-            .read_exact_at(&mut value, offset + HEADER_SIZE as u64 + key_len as u64)?;
+            .read_exact_at(&mut value, offset + HEADER_SIZE as u64 + key_len as u64)
+            .map_err(|e| {
+                anyhow!(
+                    "failed to read value at offset {} from {:?}: {}",
+                    offset + HEADER_SIZE as u64 + key_len as u64,
+                    self.path,
+                    e
+                )
+            })?;
 
         // Validate header CRC32: covers value_crc32 + value_len + key_len + flags + padding + key
         let entry_header = VlogEntryHeader {

--- a/mini-lsm-starter/src/vlog/reader.rs
+++ b/mini-lsm-starter/src/vlog/reader.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 use anyhow::{Result, anyhow};
 use bytes::Buf;
 
-use super::{ALIGNMENT, HEADER_SIZE, ValuePointer, VlogEntry, VlogEntryHeader, VlogFileHeader};
+use super::{HEADER_SIZE, ValuePointer, VlogEntry, VlogEntryHeader, VlogFileHeader};
 
 /// Lightweight header-only entry metadata for GC analysis.
 /// Contains the pointer, key, and value length without reading the value payload.
@@ -180,8 +180,8 @@ impl Iterator for VlogHeaderIterator {
             hdr_bytes.copy_to_slice(&mut padding);
 
             // Compute total entry size with alignment padding
-            let raw_size = HEADER_SIZE as u64 + key_len as u64 + value_len as u64;
-            let entry_size = raw_size.div_ceil(ALIGNMENT as u64) * ALIGNMENT as u64;
+            let entry_size = VlogEntryHeader::compute_entry_size(key_len, value_len as usize)
+                .ok_or_else(|| anyhow!("entry size overflow"))? as u64;
 
             anyhow::ensure!(entry_size <= u32::MAX as u64, "entry size exceeds u32::MAX");
             let next_offset = self

--- a/mini-lsm-starter/src/vlog/reader.rs
+++ b/mini-lsm-starter/src/vlog/reader.rs
@@ -1,7 +1,7 @@
 use std::fs::File;
 use std::io::{Read, Seek, SeekFrom};
+use std::os::unix::fs::FileExt;
 use std::path::PathBuf;
-use std::sync::Mutex;
 
 use anyhow::{Result, anyhow};
 use bytes::Buf;
@@ -19,10 +19,10 @@ pub struct VlogEntryMeta {
 
 /// Random-read vLog file reader.
 ///
-/// The `File` is wrapped in a `Mutex` so that `read_entry` can be called
-/// through `&self` (the reader is typically shared behind an `Arc`).
+/// Uses positional reads (`read_exact_at`) for concurrent, lock-free
+/// random access on Unix platforms.
 pub struct ValueLogReader {
-    file: Mutex<File>,
+    file: File,
     path: PathBuf,
     file_size: u64,
 }
@@ -37,7 +37,7 @@ impl ValueLogReader {
         VlogFileHeader::decode(&header_buf)?;
         let file_size = file.metadata()?.len();
         Ok(Self {
-            file: Mutex::new(file),
+            file,
             path,
             file_size,
         })
@@ -50,15 +50,6 @@ impl ValueLogReader {
     /// - Validates `header_crc32` and `value_crc32`
     /// - Returns a `VlogEntry` with ptr, key, value, size
     pub fn read_entry(&self, offset: u64, size: u32) -> Result<VlogEntry> {
-        // Hold the lock for the entire seek+read to avoid data corruption.
-        // File::try_clone shares the underlying file offset on Unix, so
-        // concurrent seeks on clones would race.
-        let mut file = self
-            .file
-            .lock()
-            .map_err(|e| anyhow!("lock poisoned: {}", e))?;
-        file.seek(SeekFrom::Start(offset))?;
-
         let size = size as usize;
         anyhow::ensure!(
             size >= HEADER_SIZE,
@@ -76,10 +67,7 @@ impl ValueLogReader {
         );
 
         let mut buf = vec![0u8; size];
-        file.read_exact(&mut buf)?;
-
-        // Drop the lock early — all remaining work is CPU-bound on `buf`.
-        drop(file);
+        self.file.read_exact_at(&mut buf, offset)?;
 
         // Parse header (first 24 bytes)
         let mut hdr_bytes = &buf[..HEADER_SIZE];

--- a/mini-lsm-starter/src/vlog/reader.rs
+++ b/mini-lsm-starter/src/vlog/reader.rs
@@ -24,7 +24,6 @@ pub struct VlogEntryMeta {
 pub struct ValueLogReader {
     file: File,
     path: PathBuf,
-    file_size: u64,
 }
 
 impl ValueLogReader {
@@ -35,12 +34,7 @@ impl ValueLogReader {
         let mut header_buf = [0u8; VlogFileHeader::SIZE];
         file.read_exact(&mut header_buf)?;
         VlogFileHeader::decode(&header_buf)?;
-        let file_size = file.metadata()?.len();
-        Ok(Self {
-            file,
-            path,
-            file_size,
-        })
+        Ok(Self { file, path })
     }
 
     /// Read a single entry at the given offset with the given size.
@@ -56,14 +50,6 @@ impl ValueLogReader {
             "entry size {} is smaller than header size {}",
             size,
             HEADER_SIZE
-        );
-
-        anyhow::ensure!(
-            offset + size as u64 <= self.file_size,
-            "entry offset {} and size {} exceeds file length {}",
-            offset,
-            size,
-            self.file_size
         );
 
         let mut buf = vec![0u8; size];
@@ -140,12 +126,13 @@ impl ValueLogReader {
     /// reading only headers + keys (skipping values for efficiency).
     pub fn iter_headers(&self) -> Result<VlogHeaderIterator> {
         // Open an independent file handle so the iterator does not share
-        // the underlying file offset with the Mutex-guarded random reader.
+        // the underlying file offset with the positional reader.
         let file = File::open(&self.path)?;
+        let file_size = file.metadata()?.len();
         Ok(VlogHeaderIterator {
             reader: file,
             offset: VlogFileHeader::SIZE as u64,
-            file_size: self.file_size,
+            file_size,
             file_id: 0, // caller can set via `with_file_id()`
         })
     }

--- a/mini-lsm-starter/src/vlog/reader.rs
+++ b/mini-lsm-starter/src/vlog/reader.rs
@@ -74,6 +74,18 @@ impl ValueLogReader {
             HEADER_SIZE
         );
 
+        // Guard against OOM from corrupted pointers before allocating.
+        let file_len = self.file.metadata()?.len();
+        anyhow::ensure!(
+            offset
+                .checked_add(size as u64)
+                .is_some_and(|end| end <= file_len),
+            "entry offset {} and size {} exceeds file length {}",
+            offset,
+            size,
+            file_len
+        );
+
         // Read the entire entry in a single system call to minimize I/O overhead.
         let mut buf = vec![0u8; size];
         self.file.read_exact_at(&mut buf, offset).map_err(|e| {

--- a/mini-lsm-starter/src/vlog/reader.rs
+++ b/mini-lsm-starter/src/vlog/reader.rs
@@ -25,6 +25,7 @@ pub struct ValueLogReader {
     file: File,
     path: PathBuf,
     file_id: u32,
+    file_len: u64,
 }
 
 impl ValueLogReader {
@@ -32,6 +33,7 @@ impl ValueLogReader {
     /// Reads and verifies the 16-byte `VlogFileHeader` at offset 0.
     pub fn open(path: PathBuf) -> Result<Self> {
         let mut file = File::open(&path)?;
+        let file_len = file.metadata()?.len();
         let mut header_buf = [0u8; VlogFileHeader::SIZE];
         file.read_exact(&mut header_buf)?;
         VlogFileHeader::decode(&header_buf)?;
@@ -39,6 +41,7 @@ impl ValueLogReader {
             file,
             path,
             file_id: 0,
+            file_len,
         })
     }
 
@@ -75,7 +78,7 @@ impl ValueLogReader {
         );
 
         // Guard against OOM from corrupted pointers before allocating.
-        let file_len = self.file.metadata()?.len();
+        let file_len = self.file_len;
         anyhow::ensure!(
             offset
                 .checked_add(size as u64)

--- a/mini-lsm-starter/src/vlog/reader.rs
+++ b/mini-lsm-starter/src/vlog/reader.rs
@@ -5,6 +5,7 @@ use std::fs::File;
 use std::io::{BufReader, Read, Seek, SeekFrom};
 use std::os::unix::fs::FileExt;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use anyhow::{Context, Result, anyhow};
 use bytes::Buf;
@@ -28,7 +29,7 @@ pub struct ValueLogReader {
     file: File,
     path: PathBuf,
     file_id: u32,
-    file_len: u64,
+    file_len: AtomicU64,
 }
 
 impl ValueLogReader {
@@ -50,7 +51,7 @@ impl ValueLogReader {
             file,
             path,
             file_id: 0,
-            file_len,
+            file_len: AtomicU64::new(file_len),
         })
     }
 
@@ -95,7 +96,17 @@ impl ValueLogReader {
             size,
             MAX_ENTRY_SIZE
         );
-        let file_len = self.file_len;
+        // Dynamically refresh the cached file length if the read appears to
+        // exceed it, allowing reads on actively-growing vLog files.
+        let mut file_len = self.file_len.load(Ordering::Relaxed);
+        if offset
+            .checked_add(size as u64)
+            .is_none_or(|end| end > file_len)
+        {
+            let new_len = self.file.metadata()?.len();
+            self.file_len.store(new_len, Ordering::Relaxed);
+            file_len = new_len;
+        }
         anyhow::ensure!(
             offset
                 .checked_add(size as u64)

--- a/mini-lsm-starter/src/vlog/reader.rs
+++ b/mini-lsm-starter/src/vlog/reader.rs
@@ -88,6 +88,19 @@ impl ValueLogReader {
             size
         );
 
+        // Guard against OOM from corrupted headers: ensure the entry fits
+        // within the actual physical file before allocating key/value vectors.
+        let file_len = self.file.metadata()?.len();
+        let end_offset = offset
+            .checked_add(expected_size as u64)
+            .ok_or_else(|| anyhow!("offset overflow"))?;
+        anyhow::ensure!(
+            end_offset <= file_len,
+            "entry end offset {} exceeds file length {}",
+            end_offset,
+            file_len
+        );
+
         // Read key and value directly into their destination vectors to avoid
         // copying large payloads through an intermediate buffer.
         let mut key = vec![0u8; key_len];
@@ -157,10 +170,10 @@ impl ValueLogReader {
     /// Return an iterator that yields `VlogEntryMeta` for each entry,
     /// reading only headers + keys (skipping values for efficiency).
     pub fn iter_headers(&self) -> Result<VlogHeaderIterator> {
-        // Clone the underlying file descriptor so the iterator survives
-        // path renames/unlinks, then wrap it in a BufReader for efficient
-        // sequential reads during GC analysis.
-        let mut file = self.file.try_clone()?;
+        // Open an independent file descriptor so the iterator has its own
+        // file offset, avoiding corruption when multiple iterators run
+        // concurrently. Wrap it in a BufReader for efficient sequential reads.
+        let mut file = File::open(&self.path)?;
         file.seek(SeekFrom::Start(VlogFileHeader::SIZE as u64))?;
         let file_size = file.metadata()?.len();
         Ok(VlogHeaderIterator {

--- a/mini-lsm-starter/src/vlog/reader.rs
+++ b/mini-lsm-starter/src/vlog/reader.rs
@@ -88,6 +88,13 @@ impl ValueLogReader {
         );
 
         // Guard against OOM from corrupted pointers before allocating.
+        const MAX_ENTRY_SIZE: usize = 512 * 1024 * 1024;
+        anyhow::ensure!(
+            size <= MAX_ENTRY_SIZE,
+            "entry size {} exceeds maximum allowed size ({})",
+            size,
+            MAX_ENTRY_SIZE
+        );
         let file_len = self.file_len;
         anyhow::ensure!(
             offset

--- a/mini-lsm-starter/src/vlog/reader.rs
+++ b/mini-lsm-starter/src/vlog/reader.rs
@@ -52,11 +52,13 @@ impl ValueLogReader {
             HEADER_SIZE
         );
 
-        let mut buf = vec![0u8; size];
-        self.file.read_exact_at(&mut buf, offset)?;
+        // Read the 24-byte header first to avoid allocating a huge buffer if
+        // `size` is corrupted, and to prevent double-allocating/copying the
+        // large value payload.
+        let mut hdr_buf = [0u8; HEADER_SIZE];
+        self.file.read_exact_at(&mut hdr_buf, offset)?;
 
-        // Parse header (first 24 bytes)
-        let mut hdr_bytes = &buf[..HEADER_SIZE];
+        let mut hdr_bytes = &hdr_buf[..];
         let header_crc32 = hdr_bytes.get_u32_le();
         let value_crc32 = hdr_bytes.get_u32_le();
         let value_len = hdr_bytes.get_u32_le() as usize;
@@ -79,8 +81,14 @@ impl ValueLogReader {
             size - HEADER_SIZE - key_len
         );
 
-        let key = buf[HEADER_SIZE..HEADER_SIZE + key_len].to_vec();
-        let value = buf[HEADER_SIZE + key_len..HEADER_SIZE + key_len + value_len].to_vec();
+        // Read key and value directly into their destination vectors.
+        let mut key = vec![0u8; key_len];
+        self.file
+            .read_exact_at(&mut key, offset + HEADER_SIZE as u64)?;
+
+        let mut value = vec![0u8; value_len];
+        self.file
+            .read_exact_at(&mut value, offset + HEADER_SIZE as u64 + key_len as u64)?;
 
         // Validate header CRC32: covers value_crc32 + value_len + key_len + flags + padding + key
         let entry_header = VlogEntryHeader {

--- a/mini-lsm-starter/src/vlog/reader.rs
+++ b/mini-lsm-starter/src/vlog/reader.rs
@@ -66,6 +66,7 @@ impl ValueLogReader {
     /// - Parses the 24-byte `VlogEntryHeader`, then key and value
     /// - Validates `header_crc32` and `value_crc32`
     /// - Returns a `VlogEntry` with ptr, key, value, size
+    #[allow(clippy::manual_is_multiple_of)]
     pub fn read_entry(&self, offset: u64, size: u32) -> Result<VlogEntry> {
         let size = size as usize;
         anyhow::ensure!(
@@ -74,7 +75,7 @@ impl ValueLogReader {
             offset
         );
         anyhow::ensure!(
-            offset.is_multiple_of(super::ALIGNMENT as u64),
+            offset % super::ALIGNMENT as u64 == 0,
             "offset {} is not aligned to {} bytes",
             offset,
             super::ALIGNMENT

--- a/mini-lsm-starter/src/vlog/reader.rs
+++ b/mini-lsm-starter/src/vlog/reader.rs
@@ -1,9 +1,12 @@
+#[cfg(not(unix))]
+compile_error!("vLog reader currently requires Unix platforms");
+
 use std::fs::File;
 use std::io::{BufReader, Read, Seek, SeekFrom};
 use std::os::unix::fs::FileExt;
 use std::path::PathBuf;
 
-use anyhow::{Result, anyhow};
+use anyhow::{Context, Result, anyhow};
 use bytes::Buf;
 
 use super::{HEADER_SIZE, ValuePointer, VlogEntry, VlogEntryHeader, VlogFileHeader};
@@ -32,11 +35,17 @@ impl ValueLogReader {
     /// Open a vLog file and validate its file header.
     /// Reads and verifies the 16-byte `VlogFileHeader` at offset 0.
     pub fn open(path: PathBuf) -> Result<Self> {
-        let mut file = File::open(&path)?;
-        let file_len = file.metadata()?.len();
+        let mut file =
+            File::open(&path).with_context(|| format!("failed to open vLog file {:?}", path))?;
+        let file_len = file
+            .metadata()
+            .with_context(|| format!("failed to get metadata for vLog file {:?}", path))?
+            .len();
         let mut header_buf = [0u8; VlogFileHeader::SIZE];
-        file.read_exact(&mut header_buf)?;
-        VlogFileHeader::decode(&header_buf)?;
+        file.read_exact(&mut header_buf)
+            .with_context(|| format!("failed to read header of vLog file {:?}", path))?;
+        VlogFileHeader::decode(&header_buf)
+            .with_context(|| format!("failed to decode header of vLog file {:?}", path))?;
         Ok(Self {
             file,
             path,

--- a/mini-lsm-starter/src/vlog/reader.rs
+++ b/mini-lsm-starter/src/vlog/reader.rs
@@ -45,10 +45,12 @@ impl ValueLogReader {
     /// - Validates `header_crc32` and `value_crc32`
     /// - Returns a `VlogEntry` with ptr, key, value, size
     pub fn read_entry(&self, offset: u64, size: u32) -> Result<VlogEntry> {
+        // Clone the file handle so we don't hold the lock during I/O.
         let mut file = self
             .file
             .lock()
-            .map_err(|e| anyhow!("lock poisoned: {}", e))?;
+            .map_err(|e| anyhow!("lock poisoned: {}", e))?
+            .try_clone()?;
         file.seek(SeekFrom::Start(offset))?;
 
         let size = size as usize;
@@ -210,9 +212,9 @@ impl Iterator for VlogHeaderIterator {
                 "entry extends past EOF"
             );
 
-            // Read only the key bytes (skip the value payload for efficiency)
-            let key_start = self.offset + HEADER_SIZE as u64;
-            self.reader.seek(SeekFrom::Start(key_start))?;
+            // Read only the key bytes (skip the value payload for efficiency).
+            // The file cursor is already at self.offset + HEADER_SIZE after
+            // reading the entry header, so no extra seek is needed.
             let mut key = vec![0u8; key_len];
             self.reader.read_exact(&mut key)?;
 
@@ -248,6 +250,11 @@ impl Iterator for VlogHeaderIterator {
                 entry_size: entry_size as usize,
             })
         })();
+
+        if result.is_err() {
+            // Prevent infinite loop on corruption / I/O error.
+            self.offset = self.file_size;
+        }
 
         Some(result)
     }

--- a/mini-lsm-starter/src/vlog/reader.rs
+++ b/mini-lsm-starter/src/vlog/reader.rs
@@ -51,6 +51,12 @@ impl ValueLogReader {
             offset
         );
         anyhow::ensure!(
+            offset.is_multiple_of(super::ALIGNMENT as u64),
+            "offset {} is not aligned to {} bytes",
+            offset,
+            super::ALIGNMENT
+        );
+        anyhow::ensure!(
             size >= HEADER_SIZE,
             "entry size {} is smaller than header size {}",
             size,
@@ -82,22 +88,31 @@ impl ValueLogReader {
             size
         );
 
-        // Read key and value together in a single positional read to reduce
-        // system call overhead, then split into separate vectors.
-        let mut kv_buf = vec![0u8; key_len + value_len];
+        // Read key and value directly into their destination vectors to avoid
+        // copying large payloads through an intermediate buffer.
+        let mut key = vec![0u8; key_len];
         self.file
-            .read_exact_at(&mut kv_buf, offset + HEADER_SIZE as u64)
+            .read_exact_at(&mut key, offset + HEADER_SIZE as u64)
             .map_err(|e| {
                 anyhow!(
-                    "failed to read key-value payload at offset {} from {:?}: {}",
+                    "failed to read key at offset {} from {:?}: {}",
                     offset + HEADER_SIZE as u64,
                     self.path,
                     e
                 )
             })?;
-        let (key_slice, value_slice) = kv_buf.split_at(key_len);
-        let key = key_slice.to_vec();
-        let value = value_slice.to_vec();
+
+        let mut value = vec![0u8; value_len];
+        self.file
+            .read_exact_at(&mut value, offset + HEADER_SIZE as u64 + key_len as u64)
+            .map_err(|e| {
+                anyhow!(
+                    "failed to read value at offset {} from {:?}: {}",
+                    offset + HEADER_SIZE as u64 + key_len as u64,
+                    self.path,
+                    e
+                )
+            })?;
 
         // Validate header CRC32: covers value_crc32 + value_len + key_len + flags + padding + key
         let entry_header = VlogEntryHeader {

--- a/mini-lsm-starter/src/vlog/reader.rs
+++ b/mini-lsm-starter/src/vlog/reader.rs
@@ -24,6 +24,7 @@ pub struct VlogEntryMeta {
 pub struct ValueLogReader {
     file: File,
     path: PathBuf,
+    file_id: u32,
 }
 
 impl ValueLogReader {
@@ -34,7 +35,17 @@ impl ValueLogReader {
         let mut header_buf = [0u8; VlogFileHeader::SIZE];
         file.read_exact(&mut header_buf)?;
         VlogFileHeader::decode(&header_buf)?;
-        Ok(Self { file, path })
+        Ok(Self {
+            file,
+            path,
+            file_id: 0,
+        })
+    }
+
+    /// Set the file ID for generated `ValuePointer`s.
+    pub fn with_file_id(mut self, file_id: u32) -> Self {
+        self.file_id = file_id;
+        self
     }
 
     /// Read a single entry at the given offset with the given size.
@@ -63,13 +74,19 @@ impl ValueLogReader {
             HEADER_SIZE
         );
 
-        // Read the 24-byte header first to avoid allocating a huge buffer if
-        // `size` is corrupted, and to prevent double-allocating/copying the
-        // large value payload.
-        let mut hdr_buf = [0u8; HEADER_SIZE];
-        self.file.read_exact_at(&mut hdr_buf, offset)?;
+        // Read the entire entry in a single system call to minimize I/O overhead.
+        let mut buf = vec![0u8; size];
+        self.file.read_exact_at(&mut buf, offset).map_err(|e| {
+            anyhow!(
+                "failed to read entry of size {} at offset {} from {:?}: {}",
+                size,
+                offset,
+                self.path,
+                e
+            )
+        })?;
 
-        let mut hdr_bytes = &hdr_buf[..];
+        let mut hdr_bytes = &buf[..HEADER_SIZE];
         let header_crc32 = hdr_bytes.get_u32_le();
         let value_crc32 = hdr_bytes.get_u32_le();
         let value_len = hdr_bytes.get_u32_le() as usize;
@@ -88,35 +105,11 @@ impl ValueLogReader {
             size
         );
 
-        // OOM safety: `size` originates from the trusted LSM index/manifest,
-        // and `size == expected_size` above catches header corruption.
-        // `read_exact_at` will fail with `UnexpectedEof` if the entry is past EOF.
-
-        // Read key and value directly into their destination vectors to avoid
-        // copying large payloads through an intermediate buffer.
-        let mut key = vec![0u8; key_len];
-        self.file
-            .read_exact_at(&mut key, offset + HEADER_SIZE as u64)
-            .map_err(|e| {
-                anyhow!(
-                    "failed to read key at offset {} from {:?}: {}",
-                    offset + HEADER_SIZE as u64,
-                    self.path,
-                    e
-                )
-            })?;
-
-        let mut value = vec![0u8; value_len];
-        self.file
-            .read_exact_at(&mut value, offset + HEADER_SIZE as u64 + key_len as u64)
-            .map_err(|e| {
-                anyhow!(
-                    "failed to read value at offset {} from {:?}: {}",
-                    offset + HEADER_SIZE as u64 + key_len as u64,
-                    self.path,
-                    e
-                )
-            })?;
+        let key_start = HEADER_SIZE;
+        let key_end = key_start + key_len;
+        let value_end = key_end + value_len;
+        let key = buf[key_start..key_end].to_vec();
+        let value = buf[key_end..value_end].to_vec();
 
         // Validate header CRC32: covers value_crc32 + value_len + key_len + flags + padding + key
         let entry_header = VlogEntryHeader {
@@ -148,7 +141,7 @@ impl ValueLogReader {
 
         Ok(VlogEntry {
             ptr: ValuePointer {
-                file_id: 0, // caller should fill in the correct file_id
+                file_id: self.file_id,
                 offset,
                 size: size as u32,
             },
@@ -171,7 +164,7 @@ impl ValueLogReader {
             reader: BufReader::new(file),
             offset: VlogFileHeader::SIZE as u64,
             file_size,
-            file_id: 0, // caller can set via `with_file_id()`
+            file_id: self.file_id,
         })
     }
 }

--- a/mini-lsm-starter/src/vlog/reader.rs
+++ b/mini-lsm-starter/src/vlog/reader.rs
@@ -24,6 +24,7 @@ pub struct VlogEntryMeta {
 pub struct ValueLogReader {
     file: Mutex<File>,
     path: PathBuf,
+    file_size: u64,
 }
 
 impl ValueLogReader {
@@ -34,9 +35,11 @@ impl ValueLogReader {
         let mut header_buf = [0u8; VlogFileHeader::SIZE];
         file.read_exact(&mut header_buf)?;
         VlogFileHeader::decode(&header_buf)?;
+        let file_size = file.metadata()?.len();
         Ok(Self {
             file: Mutex::new(file),
             path,
+            file_size,
         })
     }
 
@@ -64,13 +67,12 @@ impl ValueLogReader {
             HEADER_SIZE
         );
 
-        let file_len = file.metadata()?.len();
         anyhow::ensure!(
-            offset + size as u64 <= file_len,
+            offset + size as u64 <= self.file_size,
             "entry offset {} and size {} exceeds file length {}",
             offset,
             size,
-            file_len
+            self.file_size
         );
 
         let mut buf = vec![0u8; size];
@@ -152,11 +154,10 @@ impl ValueLogReader {
         // Open an independent file handle so the iterator does not share
         // the underlying file offset with the Mutex-guarded random reader.
         let file = File::open(&self.path)?;
-        let file_size = file.metadata()?.len();
         Ok(VlogHeaderIterator {
             reader: file,
             offset: VlogFileHeader::SIZE as u64,
-            file_size,
+            file_size: self.file_size,
             file_id: 0, // caller can set via `with_file_id()`
         })
     }
@@ -208,10 +209,11 @@ impl Iterator for VlogHeaderIterator {
             let entry_size = raw_size.div_ceil(ALIGNMENT as u64) * ALIGNMENT as u64;
 
             anyhow::ensure!(entry_size <= u32::MAX as u64, "entry size exceeds u32::MAX");
-            anyhow::ensure!(
-                self.offset + entry_size <= self.file_size,
-                "entry extends past EOF"
-            );
+            let next_offset = self
+                .offset
+                .checked_add(entry_size)
+                .ok_or_else(|| anyhow!("offset overflow"))?;
+            anyhow::ensure!(next_offset <= self.file_size, "entry extends past EOF");
 
             // Read only the key bytes (skip the value payload for efficiency).
             // The file cursor is already at self.offset + HEADER_SIZE after
@@ -238,7 +240,7 @@ impl Iterator for VlogHeaderIterator {
             );
 
             let current_offset = self.offset;
-            self.offset += entry_size;
+            self.offset = next_offset;
 
             Ok(VlogEntryMeta {
                 ptr: ValuePointer {

--- a/mini-lsm-starter/src/vlog/reader.rs
+++ b/mini-lsm-starter/src/vlog/reader.rs
@@ -5,7 +5,6 @@ use std::fs::File;
 use std::io::{BufReader, Read, Seek, SeekFrom};
 use std::os::unix::fs::FileExt;
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicU64, Ordering};
 
 use anyhow::{Context, Result, anyhow};
 use bytes::Buf;
@@ -29,7 +28,6 @@ pub struct ValueLogReader {
     file: File,
     path: PathBuf,
     file_id: u32,
-    file_len: AtomicU64,
 }
 
 impl ValueLogReader {
@@ -38,10 +36,6 @@ impl ValueLogReader {
     pub fn open(path: PathBuf) -> Result<Self> {
         let mut file =
             File::open(&path).with_context(|| format!("failed to open vLog file {:?}", path))?;
-        let file_len = file
-            .metadata()
-            .with_context(|| format!("failed to get metadata for vLog file {:?}", path))?
-            .len();
         let mut header_buf = [0u8; VlogFileHeader::SIZE];
         file.read_exact(&mut header_buf)
             .with_context(|| format!("failed to read header of vLog file {:?}", path))?;
@@ -51,7 +45,6 @@ impl ValueLogReader {
             file,
             path,
             file_id: 0,
-            file_len: AtomicU64::new(file_len),
         })
     }
 
@@ -96,28 +89,8 @@ impl ValueLogReader {
             size,
             MAX_ENTRY_SIZE
         );
-        // Dynamically refresh the cached file length if the read appears to
-        // exceed it, allowing reads on actively-growing vLog files.
-        let mut file_len = self.file_len.load(Ordering::Relaxed);
-        if offset
-            .checked_add(size as u64)
-            .is_none_or(|end| end > file_len)
-        {
-            let new_len = self.file.metadata()?.len();
-            self.file_len.store(new_len, Ordering::Relaxed);
-            file_len = new_len;
-        }
-        anyhow::ensure!(
-            offset
-                .checked_add(size as u64)
-                .is_some_and(|end| end <= file_len),
-            "entry offset {} and size {} exceeds file length {}",
-            offset,
-            size,
-            file_len
-        );
-
         // Read the entire entry in a single system call to minimize I/O overhead.
+        // If the entry is past EOF, `read_exact_at` will fail with UnexpectedEof.
         let mut buf = vec![0u8; size];
         self.file.read_exact_at(&mut buf, offset).map_err(|e| {
             anyhow!(

--- a/mini-lsm-starter/src/vlog/reader.rs
+++ b/mini-lsm-starter/src/vlog/reader.rs
@@ -1,0 +1,226 @@
+use std::fs::File;
+use std::io::{Read, Seek, SeekFrom};
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+use anyhow::{Result, anyhow};
+use bytes::Buf;
+
+use super::{ALIGNMENT, HEADER_SIZE, ValuePointer, VlogEntry, VlogFileHeader};
+
+/// Lightweight header-only entry metadata for GC analysis.
+/// Contains the pointer, key, and value length without reading the value payload.
+pub struct VlogEntryMeta {
+    pub ptr: ValuePointer,
+    pub key: Vec<u8>,
+    pub value_len: u32,
+    pub entry_size: usize,
+}
+
+/// Random-read vLog file reader.
+///
+/// The `File` is wrapped in a `Mutex` so that `read_entry` can be called
+/// through `&self` (the reader is typically shared behind an `Arc`).
+pub struct ValueLogReader {
+    file: Mutex<File>,
+}
+
+impl ValueLogReader {
+    /// Open a vLog file and validate its file header.
+    /// Reads and verifies the 16-byte `VlogFileHeader` at offset 0.
+    pub fn open(path: PathBuf) -> Result<Self> {
+        let mut file = File::open(&path)?;
+        let mut header_buf = [0u8; VlogFileHeader::SIZE];
+        file.read_exact(&mut header_buf)?;
+        VlogFileHeader::decode(&header_buf)?;
+        Ok(Self {
+            file: Mutex::new(file),
+        })
+    }
+
+    /// Read a single entry at the given offset with the given size.
+    ///
+    /// - Seeks to `offset`, reads `size` bytes
+    /// - Parses the 24-byte `VlogEntryHeader`, then key and value
+    /// - Validates `header_crc32` and `value_crc32`
+    /// - Returns a `VlogEntry` with ptr, key, value, size
+    pub fn read_entry(&self, offset: u64, size: u32) -> Result<VlogEntry> {
+        let mut file = self
+            .file
+            .lock()
+            .map_err(|e| anyhow!("lock poisoned: {}", e))?;
+        file.seek(SeekFrom::Start(offset))?;
+
+        let size = size as usize;
+        anyhow::ensure!(
+            size >= HEADER_SIZE,
+            "entry size {} is smaller than header size {}",
+            size,
+            HEADER_SIZE
+        );
+
+        let mut buf = vec![0u8; size];
+        file.read_exact(&mut buf)?;
+
+        // Drop the lock early — all remaining work is CPU-bound on `buf`.
+        drop(file);
+
+        // Parse header (first 24 bytes)
+        let mut hdr_bytes = &buf[..HEADER_SIZE];
+        let header_crc32 = hdr_bytes.get_u32_le();
+        let value_crc32 = hdr_bytes.get_u32_le();
+        let value_len = hdr_bytes.get_u32_le() as usize;
+        let key_len = hdr_bytes.get_u16_le() as usize;
+        let flags = hdr_bytes.get_u16_le();
+        let mut padding = [0u8; 8];
+        hdr_bytes.copy_to_slice(&mut padding);
+
+        // Bounds check
+        anyhow::ensure!(
+            HEADER_SIZE + key_len + value_len <= size,
+            "entry data (header {} + key {} + value {}) exceeds entry size {}",
+            HEADER_SIZE,
+            key_len,
+            value_len,
+            size
+        );
+
+        let key = buf[HEADER_SIZE..HEADER_SIZE + key_len].to_vec();
+        let value = buf[HEADER_SIZE + key_len..HEADER_SIZE + key_len + value_len].to_vec();
+
+        // Validate header CRC32: covers value_crc32 + value_len + key_len + flags + padding + key
+        let computed_header_crc = {
+            let mut hasher = crc32fast::Hasher::new();
+            hasher.update(&value_crc32.to_le_bytes());
+            hasher.update(&(value_len as u32).to_le_bytes());
+            hasher.update(&(key_len as u16).to_le_bytes());
+            hasher.update(&flags.to_le_bytes());
+            hasher.update(&padding);
+            hasher.update(&key);
+            hasher.finalize()
+        };
+        anyhow::ensure!(
+            computed_header_crc == header_crc32,
+            "header CRC32 mismatch: computed 0x{:08X}, stored 0x{:08X} at offset {}",
+            computed_header_crc,
+            header_crc32,
+            offset
+        );
+
+        // Validate value CRC32
+        let computed_value_crc = crc32fast::hash(&value);
+        anyhow::ensure!(
+            computed_value_crc == value_crc32,
+            "value CRC32 mismatch: computed 0x{:08X}, stored 0x{:08X} at offset {}",
+            computed_value_crc,
+            value_crc32,
+            offset
+        );
+
+        Ok(VlogEntry {
+            ptr: ValuePointer {
+                file_id: 0, // caller should fill in the correct file_id
+                offset,
+                size: size as u32,
+            },
+            key,
+            value,
+            size,
+        })
+    }
+
+    /// Return an iterator that yields `VlogEntryMeta` for each entry,
+    /// reading only headers + keys (skipping values for efficiency).
+    pub fn iter_headers(&self) -> Result<VlogHeaderIterator> {
+        let file = self
+            .file
+            .lock()
+            .map_err(|e| anyhow!("lock poisoned: {}", e))?
+            .try_clone()?;
+        let file_size = file.metadata()?.len();
+        Ok(VlogHeaderIterator {
+            reader: file,
+            offset: VlogFileHeader::SIZE as u64,
+            file_size,
+            file_id: 0, // caller can set via `with_file_id()`
+        })
+    }
+}
+
+/// Header-only iterator for GC analysis.
+/// Reads only the header and key for each entry, skipping value payloads.
+pub struct VlogHeaderIterator {
+    reader: File,
+    offset: u64,
+    file_size: u64,
+    file_id: u32,
+}
+
+impl VlogHeaderIterator {
+    /// Set the file ID for generated `ValuePointer`s.
+    pub fn with_file_id(mut self, file_id: u32) -> Self {
+        self.file_id = file_id;
+        self
+    }
+}
+
+impl Iterator for VlogHeaderIterator {
+    type Item = VlogEntryMeta;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // Stop at EOF
+        if self.offset >= self.file_size {
+            return None;
+        }
+
+        // Read the 24-byte entry header
+        let mut hdr_buf = [0u8; HEADER_SIZE];
+        if self.reader.seek(SeekFrom::Start(self.offset)).is_err() {
+            return None;
+        }
+        if self.reader.read_exact(&mut hdr_buf).is_err() {
+            return None;
+        }
+
+        let mut hdr_bytes: &[u8] = &hdr_buf;
+        let _header_crc32 = hdr_bytes.get_u32_le();
+        let _value_crc32 = hdr_bytes.get_u32_le();
+        let value_len = hdr_bytes.get_u32_le();
+        let key_len = hdr_bytes.get_u16_le() as usize;
+        let _flags = hdr_bytes.get_u16_le();
+        let _padding = hdr_bytes.get_u64_le(); // 8 bytes
+
+        // Compute total entry size with alignment padding
+        let raw_size = HEADER_SIZE + key_len + value_len as usize;
+        let entry_size = raw_size.div_ceil(ALIGNMENT) * ALIGNMENT;
+
+        // Sanity check: entry must not extend past EOF
+        if self.offset + entry_size as u64 > self.file_size {
+            return None;
+        }
+
+        // Read only the key bytes (skip the value payload for efficiency)
+        let key_start = self.offset + HEADER_SIZE as u64;
+        if self.reader.seek(SeekFrom::Start(key_start)).is_err() {
+            return None;
+        }
+        let mut key = vec![0u8; key_len];
+        if self.reader.read_exact(&mut key).is_err() {
+            return None;
+        }
+
+        let current_offset = self.offset;
+        self.offset += entry_size as u64;
+
+        Some(VlogEntryMeta {
+            ptr: ValuePointer {
+                file_id: self.file_id,
+                offset: current_offset,
+                size: entry_size as u32,
+            },
+            key,
+            value_len,
+            entry_size,
+        })
+    }
+}

--- a/mini-lsm-starter/src/vlog/reader.rs
+++ b/mini-lsm-starter/src/vlog/reader.rs
@@ -1,5 +1,5 @@
 use std::fs::File;
-use std::io::Read;
+use std::io::{BufReader, Read, Seek, SeekFrom};
 use std::os::unix::fs::FileExt;
 use std::path::PathBuf;
 
@@ -45,6 +45,11 @@ impl ValueLogReader {
     /// - Returns a `VlogEntry` with ptr, key, value, size
     pub fn read_entry(&self, offset: u64, size: u32) -> Result<VlogEntry> {
         let size = size as usize;
+        anyhow::ensure!(
+            offset >= VlogFileHeader::SIZE as u64,
+            "offset {} is within the file header region",
+            offset
+        );
         anyhow::ensure!(
             size >= HEADER_SIZE,
             "entry size {} is smaller than header size {}",
@@ -138,12 +143,13 @@ impl ValueLogReader {
     /// reading only headers + keys (skipping values for efficiency).
     pub fn iter_headers(&self) -> Result<VlogHeaderIterator> {
         // Clone the underlying file descriptor so the iterator survives
-        // path renames/unlinks and does not share the file offset with
-        // concurrent positional reads.
-        let file = self.file.try_clone()?;
+        // path renames/unlinks, then wrap it in a BufReader for efficient
+        // sequential reads during GC analysis.
+        let mut file = self.file.try_clone()?;
+        file.seek(SeekFrom::Start(VlogFileHeader::SIZE as u64))?;
         let file_size = file.metadata()?.len();
         Ok(VlogHeaderIterator {
-            reader: file,
+            reader: BufReader::new(file),
             offset: VlogFileHeader::SIZE as u64,
             file_size,
             file_id: 0, // caller can set via `with_file_id()`
@@ -154,7 +160,7 @@ impl ValueLogReader {
 /// Header-only iterator for GC analysis.
 /// Reads only the header and key for each entry, skipping value payloads.
 pub struct VlogHeaderIterator {
-    reader: File,
+    reader: BufReader<File>,
     offset: u64,
     file_size: u64,
     file_id: u32,
@@ -178,9 +184,9 @@ impl Iterator for VlogHeaderIterator {
         }
 
         let result = (|| -> Result<VlogEntryMeta> {
-            // Read the 24-byte entry header via positional read
+            // Read the 24-byte entry header sequentially
             let mut hdr_buf = [0u8; HEADER_SIZE];
-            self.reader.read_exact_at(&mut hdr_buf, self.offset)?;
+            self.reader.read_exact(&mut hdr_buf)?;
 
             let mut hdr_bytes: &[u8] = &hdr_buf;
             let header_crc32 = hdr_bytes.get_u32_le();
@@ -204,8 +210,13 @@ impl Iterator for VlogHeaderIterator {
 
             // Read only the key bytes (skip the value payload for efficiency).
             let mut key = vec![0u8; key_len];
-            self.reader
-                .read_exact_at(&mut key, self.offset + HEADER_SIZE as u64)?;
+            self.reader.read_exact(&mut key)?;
+
+            // Skip value + padding to position cursor for the next entry.
+            let skip = entry_size as i64 - HEADER_SIZE as i64 - key_len as i64;
+            if skip > 0 {
+                self.reader.seek(SeekFrom::Current(skip))?;
+            }
 
             // Validate header CRC32
             let entry_header = VlogEntryHeader {

--- a/mini-lsm-starter/src/vlog/reader.rs
+++ b/mini-lsm-starter/src/vlog/reader.rs
@@ -23,6 +23,7 @@ pub struct VlogEntryMeta {
 /// through `&self` (the reader is typically shared behind an `Arc`).
 pub struct ValueLogReader {
     file: Mutex<File>,
+    path: PathBuf,
 }
 
 impl ValueLogReader {
@@ -35,6 +36,7 @@ impl ValueLogReader {
         VlogFileHeader::decode(&header_buf)?;
         Ok(Self {
             file: Mutex::new(file),
+            path,
         })
     }
 
@@ -45,12 +47,13 @@ impl ValueLogReader {
     /// - Validates `header_crc32` and `value_crc32`
     /// - Returns a `VlogEntry` with ptr, key, value, size
     pub fn read_entry(&self, offset: u64, size: u32) -> Result<VlogEntry> {
-        // Clone the file handle so we don't hold the lock during I/O.
+        // Hold the lock for the entire seek+read to avoid data corruption.
+        // File::try_clone shares the underlying file offset on Unix, so
+        // concurrent seeks on clones would race.
         let mut file = self
             .file
             .lock()
-            .map_err(|e| anyhow!("lock poisoned: {}", e))?
-            .try_clone()?;
+            .map_err(|e| anyhow!("lock poisoned: {}", e))?;
         file.seek(SeekFrom::Start(offset))?;
 
         let size = size as usize;
@@ -146,11 +149,9 @@ impl ValueLogReader {
     /// Return an iterator that yields `VlogEntryMeta` for each entry,
     /// reading only headers + keys (skipping values for efficiency).
     pub fn iter_headers(&self) -> Result<VlogHeaderIterator> {
-        let file = self
-            .file
-            .lock()
-            .map_err(|e| anyhow!("lock poisoned: {}", e))?
-            .try_clone()?;
+        // Open an independent file handle so the iterator does not share
+        // the underlying file offset with the Mutex-guarded random reader.
+        let file = File::open(&self.path)?;
         let file_size = file.metadata()?.len();
         Ok(VlogHeaderIterator {
             reader: file,

--- a/mini-lsm-starter/src/vlog/reader.rs
+++ b/mini-lsm-starter/src/vlog/reader.rs
@@ -1,5 +1,5 @@
 use std::fs::File;
-use std::io::{Read, Seek, SeekFrom};
+use std::io::Read;
 use std::os::unix::fs::FileExt;
 use std::path::PathBuf;
 
@@ -77,30 +77,22 @@ impl ValueLogReader {
             size
         );
 
-        // Read key and value directly into their destination vectors.
-        let mut key = vec![0u8; key_len];
+        // Read key and value together in a single positional read to reduce
+        // system call overhead, then split into separate vectors.
+        let mut kv_buf = vec![0u8; key_len + value_len];
         self.file
-            .read_exact_at(&mut key, offset + HEADER_SIZE as u64)
+            .read_exact_at(&mut kv_buf, offset + HEADER_SIZE as u64)
             .map_err(|e| {
                 anyhow!(
-                    "failed to read key at offset {} from {:?}: {}",
+                    "failed to read key-value payload at offset {} from {:?}: {}",
                     offset + HEADER_SIZE as u64,
                     self.path,
                     e
                 )
             })?;
-
-        let mut value = vec![0u8; value_len];
-        self.file
-            .read_exact_at(&mut value, offset + HEADER_SIZE as u64 + key_len as u64)
-            .map_err(|e| {
-                anyhow!(
-                    "failed to read value at offset {} from {:?}: {}",
-                    offset + HEADER_SIZE as u64 + key_len as u64,
-                    self.path,
-                    e
-                )
-            })?;
+        let (key_slice, value_slice) = kv_buf.split_at(key_len);
+        let key = key_slice.to_vec();
+        let value = value_slice.to_vec();
 
         // Validate header CRC32: covers value_crc32 + value_len + key_len + flags + padding + key
         let entry_header = VlogEntryHeader {
@@ -145,9 +137,10 @@ impl ValueLogReader {
     /// Return an iterator that yields `VlogEntryMeta` for each entry,
     /// reading only headers + keys (skipping values for efficiency).
     pub fn iter_headers(&self) -> Result<VlogHeaderIterator> {
-        // Open an independent file handle so the iterator does not share
-        // the underlying file offset with the positional reader.
-        let file = File::open(&self.path)?;
+        // Clone the underlying file descriptor so the iterator survives
+        // path renames/unlinks and does not share the file offset with
+        // concurrent positional reads.
+        let file = self.file.try_clone()?;
         let file_size = file.metadata()?.len();
         Ok(VlogHeaderIterator {
             reader: file,
@@ -185,10 +178,9 @@ impl Iterator for VlogHeaderIterator {
         }
 
         let result = (|| -> Result<VlogEntryMeta> {
-            // Read the 24-byte entry header
+            // Read the 24-byte entry header via positional read
             let mut hdr_buf = [0u8; HEADER_SIZE];
-            self.reader.seek(SeekFrom::Start(self.offset))?;
-            self.reader.read_exact(&mut hdr_buf)?;
+            self.reader.read_exact_at(&mut hdr_buf, self.offset)?;
 
             let mut hdr_bytes: &[u8] = &hdr_buf;
             let header_crc32 = hdr_bytes.get_u32_le();
@@ -211,10 +203,9 @@ impl Iterator for VlogHeaderIterator {
             anyhow::ensure!(next_offset <= self.file_size, "entry extends past EOF");
 
             // Read only the key bytes (skip the value payload for efficiency).
-            // The file cursor is already at self.offset + HEADER_SIZE after
-            // reading the entry header, so no extra seek is needed.
             let mut key = vec![0u8; key_len];
-            self.reader.read_exact(&mut key)?;
+            self.reader
+                .read_exact_at(&mut key, self.offset + HEADER_SIZE as u64)?;
 
             // Validate header CRC32
             let entry_header = VlogEntryHeader {


### PR DESCRIPTION
## Summary

Phase 1 of key-value separation implementation. Adds the value log (vLog) module — the core infrastructure for storing large values separately from the LSM tree.

## Changes

New module `src/vlog/` with:

- **Types**: `ValuePointer` (17-byte encode/decode), `KvKind` (Inline vs ValuePointer), `ValueSeparationOptions`, `VlogFileHeader`, `VlogEntryHeader`, `VlogEntry`
- **Writer**: `ValueLogWriter` (sequential append, CRC32 checksums, 8-byte alignment, fsync) and `ValueLogBuilder` (per-flush builder with key/value size validation)
- **Reader**: `ValueLogReader` (random read with CRC validation) and `VlogHeaderIterator` (header-only iterator for GC analysis)
- **Tests**: 9 unit tests covering encode/decode round-trips, CRC validation, write/read round-trips, alignment, large entries, header iteration, and corruption detection

Dependencies: added `crc32fast = "1.3.2"`

## Verification

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -D warnings` — clean
- [x] `cargo test -p mini-lsm-starter --lib vlog` — 9/9 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)