### PR TITLE
feat: add ValueLog manager with reader cache and reference tracking

### DIFF
--- a/mini-lsm-starter/src/vlog/mod.rs
+++ b/mini-lsm-starter/src/vlog/mod.rs
@@ -397,9 +397,9 @@ impl ValueLog {
 
     /// Get a cached reader for `file_id`, opening it on cache miss.
     pub fn get_reader(&self, file_id: u32) -> Result<Arc<ValueLogReader>> {
-        let path = self.path_of_file(file_id);
         self.readers
             .try_get_with(file_id, || {
+                let path = self.path_of_file(file_id);
                 let reader = ValueLogReader::open(path)?.with_file_id(file_id);
                 Ok::<_, anyhow::Error>(Arc::new(reader))
             })

--- a/mini-lsm-starter/src/vlog/mod.rs
+++ b/mini-lsm-starter/src/vlog/mod.rs
@@ -242,11 +242,14 @@ pub struct VlogEntry {
 // =============================================================================
 
 /// Tracks which vLog files are referenced by each SST.
+struct VlogReferencesInner {
+    sst_to_vlogs: HashMap<usize, HashSet<u32>>,
+    vlog_to_ssts: HashMap<u32, HashSet<usize>>,
+}
+
+/// Tracks which vLog files are referenced by each SST.
 pub struct VlogReferences {
-    /// SST id -> set of vLog file ids it references.
-    sst_to_vlogs: RwLock<HashMap<usize, HashSet<u32>>>,
-    /// vLog file id -> set of SST ids that reference it.
-    vlog_to_ssts: RwLock<HashMap<u32, HashSet<usize>>>,
+    inner: RwLock<VlogReferencesInner>,
 }
 
 impl Default for VlogReferences {
@@ -258,49 +261,67 @@ impl Default for VlogReferences {
 impl VlogReferences {
     pub fn new() -> Self {
         Self {
-            sst_to_vlogs: RwLock::new(HashMap::new()),
-            vlog_to_ssts: RwLock::new(HashMap::new()),
+            inner: RwLock::new(VlogReferencesInner {
+                sst_to_vlogs: HashMap::new(),
+                vlog_to_ssts: HashMap::new(),
+            }),
         }
     }
 
     /// Register that `sst_id` references the given vLog file ids.
+    /// Replaces any existing references for this `sst_id` to prevent leaks.
     pub fn register(&self, sst_id: usize, vlog_ids: &[u32]) {
+        let mut inner = self.inner.write();
+        // Remove old mappings first to prevent leaks on re-registration.
+        if let Some(old_ids) = inner.sst_to_vlogs.remove(&sst_id) {
+            for vid in old_ids {
+                if let Some(ssts) = inner.vlog_to_ssts.get_mut(&vid) {
+                    ssts.remove(&sst_id);
+                    if ssts.is_empty() {
+                        inner.vlog_to_ssts.remove(&vid);
+                    }
+                }
+            }
+        }
         if vlog_ids.is_empty() {
             return;
         }
-        let mut s2v = self.sst_to_vlogs.write();
-        let mut v2s = self.vlog_to_ssts.write();
-        let set = s2v.entry(sst_id).or_default();
-        for &vid in vlog_ids {
-            set.insert(vid);
-            v2s.entry(vid).or_default().insert(sst_id);
+        let set: HashSet<u32> = vlog_ids.iter().copied().collect();
+        for &vid in &set {
+            inner.vlog_to_ssts.entry(vid).or_default().insert(sst_id);
         }
+        inner.sst_to_vlogs.insert(sst_id, set);
     }
 
     /// Get the set of vLog file ids referenced by `sst_id`.
     pub fn get_sst_references(&self, sst_id: usize) -> Option<Vec<u32>> {
-        let s2v = self.sst_to_vlogs.read();
-        s2v.get(&sst_id).map(|set| set.iter().copied().collect())
+        let inner = self.inner.read();
+        inner
+            .sst_to_vlogs
+            .get(&sst_id)
+            .map(|set| set.iter().copied().collect())
     }
 
     /// Get the set of SST ids that reference `vlog_id`.
     pub fn get_ssts_referencing(&self, vlog_id: u32) -> Option<Vec<usize>> {
-        let v2s = self.vlog_to_ssts.read();
-        v2s.get(&vlog_id).map(|set| set.iter().copied().collect())
+        let inner = self.inner.read();
+        inner
+            .vlog_to_ssts
+            .get(&vlog_id)
+            .map(|set| set.iter().copied().collect())
     }
 
     /// Unregister all references for `sst_id` and return the previously
     /// referenced vLog file ids.
     pub fn unregister(&self, sst_id: usize) -> Vec<u32> {
-        let mut s2v = self.sst_to_vlogs.write();
-        let mut v2s = self.vlog_to_ssts.write();
-        let vlog_ids = s2v.remove(&sst_id);
-        if let Some(ref ids) = vlog_ids {
+        let mut inner = self.inner.write();
+        let vlog_ids = inner.sst_to_vlogs.remove(&sst_id);
+        if let Some(ids) = &vlog_ids {
             for vid in ids {
-                if let Some(ssts) = v2s.get_mut(vid) {
+                if let Some(ssts) = inner.vlog_to_ssts.get_mut(vid) {
                     ssts.remove(&sst_id);
                     if ssts.is_empty() {
-                        v2s.remove(vid);
+                        inner.vlog_to_ssts.remove(vid);
                     }
                 }
             }
@@ -375,7 +396,7 @@ impl ValueLog {
         let path = self.path_of_file(file_id);
         self.readers
             .try_get_with(file_id, || {
-                let reader = ValueLogReader::open(path)?;
+                let reader = ValueLogReader::open(path)?.with_file_id(file_id);
                 Ok::<_, anyhow::Error>(Arc::new(reader))
             })
             .map_err(|e| anyhow!("failed to open vlog reader {}: {}", file_id, e))
@@ -418,13 +439,13 @@ impl ValueLog {
 
     /// Remove a vLog file from disk and the reader cache.
     pub fn remove_file(&self, file_id: u32) -> Result<()> {
-        self.readers.invalidate(&file_id);
         let path = self.path_of_file(file_id);
         if let Err(e) = std::fs::remove_file(&path) {
             if e.kind() != std::io::ErrorKind::NotFound {
                 return Err(e.into());
             }
         }
+        self.readers.invalidate(&file_id);
         Ok(())
     }
 
@@ -447,7 +468,11 @@ impl ValueLog {
         let mut deleted = 0usize;
         let mut first_err = None;
         for file_id in to_process {
-            if self.get_ssts_referencing(file_id).is_none() {
+            if self
+                .get_ssts_referencing(file_id)
+                .unwrap_or_default()
+                .is_empty()
+            {
                 match self.remove_file(file_id) {
                     Ok(()) => deleted += 1,
                     Err(e) => {

--- a/mini-lsm-starter/src/vlog/mod.rs
+++ b/mini-lsm-starter/src/vlog/mod.rs
@@ -286,7 +286,7 @@ impl VlogReferences {
         if vlog_ids.is_empty() {
             return;
         }
-        let set: HashSet<u32> = vlog_ids.iter().copied().collect();
+        let set: HashSet<u32> = HashSet::from_iter(vlog_ids.iter().copied());
         for &vid in &set {
             inner.vlog_to_ssts.entry(vid).or_default().insert(sst_id);
         }
@@ -315,9 +315,8 @@ impl VlogReferences {
     /// referenced vLog file ids.
     pub fn unregister(&self, sst_id: usize) -> Vec<u32> {
         let mut inner = self.inner.write();
-        let vlog_ids = inner.sst_to_vlogs.remove(&sst_id);
-        if let Some(ids) = &vlog_ids {
-            for vid in ids {
+        if let Some(vlog_ids) = inner.sst_to_vlogs.remove(&sst_id) {
+            for vid in &vlog_ids {
                 if let Some(ssts) = inner.vlog_to_ssts.get_mut(vid) {
                     ssts.remove(&sst_id);
                     if ssts.is_empty() {
@@ -325,8 +324,10 @@ impl VlogReferences {
                     }
                 }
             }
+            vlog_ids.into_iter().collect()
+        } else {
+            Vec::new()
         }
-        vlog_ids.map_or_else(Vec::new, |set| set.into_iter().collect())
     }
 }
 
@@ -359,11 +360,14 @@ impl ValueLog {
         let mut max_id: Option<u32> = None;
         for entry in std::fs::read_dir(&path)? {
             let entry = entry?;
+            if !entry.file_type()?.is_file() {
+                continue;
+            }
             let name = entry.file_name();
             if let Some(name) = name.to_str() {
                 if let Some(stem) = name.strip_suffix(".vlog") {
                     if let Ok(id) = stem.parse::<u32>() {
-                        max_id = Some(max_id.map_or(id, |m| std::cmp::max(m, id)));
+                        max_id = Some(max_id.map_or(id, |m| m.max(id)));
                     }
                 }
             }
@@ -462,8 +466,10 @@ impl ValueLog {
     /// Attempt to delete any pending vLog files that are no longer
     /// referenced by any SST.
     pub fn reclaim_pending_deletions(&self) -> Result<usize> {
-        let mut pending = self.pending_deletions.lock();
-        let to_process: Vec<u32> = std::mem::take(&mut *pending);
+        let to_process: Vec<u32> = {
+            let mut pending = self.pending_deletions.lock();
+            std::mem::take(&mut *pending)
+        };
         let mut remaining = Vec::new();
         let mut deleted = 0usize;
         let mut first_err = None;
@@ -484,7 +490,10 @@ impl ValueLog {
                 remaining.push(file_id);
             }
         }
-        *pending = remaining;
+        {
+            let mut pending = self.pending_deletions.lock();
+            *pending = remaining;
+        }
         match first_err {
             Some(e) => Err(e),
             None => Ok(deleted),

--- a/mini-lsm-starter/src/vlog/mod.rs
+++ b/mini-lsm-starter/src/vlog/mod.rs
@@ -340,15 +340,15 @@ impl ValueLog {
         let path = path.as_ref().to_path_buf();
         std::fs::create_dir_all(&path)?;
 
-        let mut max_id = 0u32;
+        let mut max_id: Option<u32> = None;
         for entry in std::fs::read_dir(&path)? {
             let entry = entry?;
             let name = entry.file_name();
             let name = name.to_string_lossy();
-            if let Some(stem) = name.strip_suffix(".vlog")
-                && let Ok(id) = stem.parse::<u32>()
-            {
-                max_id = max_id.max(id);
+            if let Some(stem) = name.strip_suffix(".vlog") {
+                if let Ok(id) = stem.parse::<u32>() {
+                    max_id = Some(max_id.map_or(id, |m| std::cmp::max(m, id)));
+                }
             }
         }
 
@@ -357,7 +357,7 @@ impl ValueLog {
         Ok(Self {
             path,
             options,
-            next_file_id: AtomicU32::new(max_id + 1),
+            next_file_id: AtomicU32::new(max_id.map_or(0, |id| id + 1)),
             readers,
             references: VlogReferences::new(),
             pending_deletions: Mutex::new(Vec::new()),
@@ -424,8 +424,10 @@ impl ValueLog {
     pub fn remove_file(&self, file_id: u32) -> Result<()> {
         self.readers.invalidate(&file_id);
         let path = self.path_of_file(file_id);
-        if path.exists() {
-            std::fs::remove_file(&path)?;
+        if let Err(e) = std::fs::remove_file(&path) {
+            if e.kind() != std::io::ErrorKind::NotFound {
+                return Err(e.into());
+            }
         }
         Ok(())
     }
@@ -444,18 +446,28 @@ impl ValueLog {
     /// referenced by any SST.
     pub fn reclaim_pending_deletions(&self) -> Result<usize> {
         let mut pending = self.pending_deletions.lock();
-        let mut remaining = Vec::with_capacity(pending.len());
+        let to_process: Vec<u32> = std::mem::take(&mut *pending);
+        let mut remaining = Vec::new();
         let mut deleted = 0usize;
-        for file_id in pending.drain(..) {
+        let mut first_err = None;
+        for file_id in to_process {
             if self.get_ssts_referencing(file_id).is_none() {
-                self.remove_file(file_id)?;
-                deleted += 1;
+                match self.remove_file(file_id) {
+                    Ok(()) => deleted += 1,
+                    Err(e) => {
+                        first_err = Some(e);
+                        remaining.push(file_id);
+                    }
+                }
             } else {
                 remaining.push(file_id);
             }
         }
         *pending = remaining;
-        Ok(deleted)
+        match first_err {
+            Some(e) => Err(e),
+            None => Ok(deleted),
+        }
     }
 }
 

--- a/mini-lsm-starter/src/vlog/mod.rs
+++ b/mini-lsm-starter/src/vlog/mod.rs
@@ -356,6 +356,11 @@ impl ValueLog {
     pub fn open(path: impl AsRef<Path>, options: ValueSeparationOptions) -> Result<Self> {
         let path = path.as_ref().to_path_buf();
         std::fs::create_dir_all(&path)?;
+        anyhow::ensure!(
+            options.max_open_vlog_files >= 1,
+            "max_open_vlog_files must be at least 1, got {}",
+            options.max_open_vlog_files
+        );
 
         let mut max_id: Option<u32> = None;
         for entry in std::fs::read_dir(&path)? {

--- a/mini-lsm-starter/src/vlog/mod.rs
+++ b/mini-lsm-starter/src/vlog/mod.rs
@@ -4,8 +4,15 @@ pub mod reader;
 pub use builder::ValueLogBuilder;
 pub use reader::{ValueLogReader, VlogEntryMeta};
 
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
+
 use anyhow::{Result, anyhow};
-use bytes::{Buf, BufMut};
+use bytes::{Buf, BufMut, Bytes};
+use moka::sync::Cache;
+use parking_lot::{Mutex, RwLock};
 
 /// Magic number for vLog file header
 const VLOG_MAGIC: u32 = 0x564C4F47; // "VLOG"
@@ -228,6 +235,228 @@ pub struct VlogEntry {
     pub key: Vec<u8>,
     pub value: Vec<u8>,
     pub size: usize,
+}
+
+// =============================================================================
+// ValueLog Manager (Phase 2 — SSTable Integration)
+// =============================================================================
+
+/// Handle to a cached vLog reader with shared ownership.
+pub struct ValueLogReaderHandle {
+    pub reader: ValueLogReader,
+}
+
+/// Tracks which vLog files are referenced by each SST.
+pub struct VlogReferences {
+    /// SST id -> set of vLog file ids it references.
+    sst_to_vlogs: RwLock<HashMap<usize, HashSet<u32>>>,
+    /// vLog file id -> set of SST ids that reference it.
+    vlog_to_ssts: RwLock<HashMap<u32, HashSet<usize>>>,
+}
+
+impl Default for VlogReferences {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl VlogReferences {
+    pub fn new() -> Self {
+        Self {
+            sst_to_vlogs: RwLock::new(HashMap::new()),
+            vlog_to_ssts: RwLock::new(HashMap::new()),
+        }
+    }
+
+    /// Register that `sst_id` references the given vLog file ids.
+    pub fn register(&self, sst_id: usize, vlog_ids: &[u32]) {
+        if vlog_ids.is_empty() {
+            return;
+        }
+        let mut s2v = self.sst_to_vlogs.write();
+        let mut v2s = self.vlog_to_ssts.write();
+        let set = s2v.entry(sst_id).or_default();
+        for &vid in vlog_ids {
+            set.insert(vid);
+            v2s.entry(vid).or_default().insert(sst_id);
+        }
+    }
+
+    /// Get the set of vLog file ids referenced by `sst_id`.
+    pub fn get_sst_references(&self, sst_id: usize) -> Option<Vec<u32>> {
+        let s2v = self.sst_to_vlogs.read();
+        s2v.get(&sst_id).map(|set| set.iter().copied().collect())
+    }
+
+    /// Get the set of SST ids that reference `vlog_id`.
+    pub fn get_ssts_referencing(&self, vlog_id: u32) -> Option<Vec<usize>> {
+        let v2s = self.vlog_to_ssts.read();
+        v2s.get(&vlog_id).map(|set| set.iter().copied().collect())
+    }
+
+    /// Unregister all references for `sst_id` and return the previously
+    /// referenced vLog file ids.
+    pub fn unregister(&self, sst_id: usize) -> Vec<u32> {
+        let mut s2v = self.sst_to_vlogs.write();
+        let mut v2s = self.vlog_to_ssts.write();
+        let vlog_ids = s2v.remove(&sst_id);
+        if let Some(ref ids) = vlog_ids {
+            for vid in ids {
+                if let Some(ssts) = v2s.get_mut(vid) {
+                    ssts.remove(&sst_id);
+                    if ssts.is_empty() {
+                        v2s.remove(vid);
+                    }
+                }
+            }
+        }
+        vlog_ids.map_or_else(Vec::new, |set| set.into_iter().collect())
+    }
+}
+
+/// Manager for the value log file set.
+///
+/// Owns the active writer (for flushing), a cache of open readers, and
+/// reference tracking between SSTs and vLog files.
+pub struct ValueLog {
+    /// Root directory where vLog files are stored.
+    pub path: PathBuf,
+    /// Options controlling key-value separation.
+    pub options: ValueSeparationOptions,
+    /// Monotonically increasing file id for the *next* vLog file to create.
+    next_file_id: AtomicU32,
+    /// Cache of open readers keyed by `file_id`.
+    readers: Cache<u32, Arc<ValueLogReaderHandle>>,
+    /// Tracks which SSTs reference which vLog files.
+    pub references: VlogReferences,
+    /// Pending vLog file ids waiting for GC reclaim (Phase 3).
+    pending_deletions: Mutex<Vec<u32>>,
+}
+
+impl ValueLog {
+    /// Open the vLog manager. Scans `path` for existing `*.vlog` files
+    /// and sets `next_file_id` to one past the highest found id.
+    pub fn open(path: impl AsRef<Path>, options: ValueSeparationOptions) -> Result<Self> {
+        let path = path.as_ref().to_path_buf();
+        std::fs::create_dir_all(&path)?;
+
+        let mut max_id = 0u32;
+        for entry in std::fs::read_dir(&path)? {
+            let entry = entry?;
+            let name = entry.file_name();
+            let name = name.to_string_lossy();
+            if let Some(stem) = name.strip_suffix(".vlog")
+                && let Ok(id) = stem.parse::<u32>()
+            {
+                max_id = max_id.max(id);
+            }
+        }
+
+        let readers = Cache::new(options.max_open_vlog_files as u64);
+
+        Ok(Self {
+            path,
+            options,
+            next_file_id: AtomicU32::new(max_id + 1),
+            readers,
+            references: VlogReferences::new(),
+            pending_deletions: Mutex::new(Vec::new()),
+        })
+    }
+
+    /// Return the next vLog file id to use for a new file.
+    pub fn next_file_id(&self) -> u32 {
+        self.next_file_id.fetch_add(1, Ordering::SeqCst)
+    }
+
+    /// Full path for a given vLog file id.
+    pub fn path_of_file(&self, file_id: u32) -> PathBuf {
+        self.path.join(format!("{}.vlog", file_id))
+    }
+
+    /// Get a cached reader for `file_id`, opening it on cache miss.
+    pub fn get_reader(&self, file_id: u32) -> Result<Arc<ValueLogReaderHandle>> {
+        let path = self.path_of_file(file_id);
+        self.readers
+            .try_get_with(file_id, || {
+                let reader = ValueLogReader::open(path.clone())?;
+                Ok::<_, anyhow::Error>(Arc::new(ValueLogReaderHandle { reader }))
+            })
+            .map_err(|e| anyhow!("failed to open vlog reader {}: {}", file_id, e))
+    }
+
+    /// Read the value at `ptr`, verifying that the stored key matches
+    /// `expected_key`.
+    pub fn read(&self, ptr: &ValuePointer, expected_key: &[u8]) -> Result<Bytes> {
+        let handle = self.get_reader(ptr.file_id)?;
+        let entry = handle.reader.read_entry(ptr.offset, ptr.size)?;
+        if entry.key != expected_key {
+            return Err(anyhow!(
+                "vlog key mismatch: expected {:?}, got {:?}",
+                expected_key,
+                entry.key
+            ));
+        }
+        Ok(Bytes::from(entry.value))
+    }
+
+    /// Register that `sst_id` references the given vLog file ids.
+    pub fn register_sst_references(&self, sst_id: usize, vlog_ids: &[u32]) {
+        self.references.register(sst_id, vlog_ids);
+    }
+
+    /// Get the vLog file ids referenced by `sst_id`.
+    pub fn get_sst_references(&self, sst_id: usize) -> Option<Vec<u32>> {
+        self.references.get_sst_references(sst_id)
+    }
+
+    /// Get the SST ids that reference `vlog_id`.
+    pub fn get_ssts_referencing(&self, vlog_id: u32) -> Option<Vec<usize>> {
+        self.references.get_ssts_referencing(vlog_id)
+    }
+
+    /// Remove all reference tracking for `sst_id`.
+    pub fn unregister_sst_references(&self, sst_id: usize) -> Vec<u32> {
+        self.references.unregister(sst_id)
+    }
+
+    /// Remove a vLog file from disk and the reader cache.
+    pub fn remove_file(&self, file_id: u32) -> Result<()> {
+        self.readers.invalidate(&file_id);
+        let path = self.path_of_file(file_id);
+        if path.exists() {
+            std::fs::remove_file(&path)?;
+        }
+        Ok(())
+    }
+
+    // -----------------------------------------------------------------
+    // Phase 3 placeholders (GC)
+    // -----------------------------------------------------------------
+
+    /// Schedule a vLog file for later deletion once all SST references
+    /// are dropped. Called during GC.
+    pub fn schedule_deletion(&self, file_id: u32) {
+        self.pending_deletions.lock().push(file_id);
+    }
+
+    /// Attempt to delete any pending vLog files that are no longer
+    /// referenced by any SST.
+    pub fn reclaim_pending_deletions(&self) -> Result<usize> {
+        let mut pending = self.pending_deletions.lock();
+        let mut remaining = Vec::with_capacity(pending.len());
+        let mut deleted = 0usize;
+        for file_id in pending.drain(..) {
+            if self.get_ssts_referencing(file_id).is_none() {
+                self.remove_file(file_id)?;
+                deleted += 1;
+            } else {
+                remaining.push(file_id);
+            }
+        }
+        *pending = remaining;
+        Ok(deleted)
+    }
 }
 
 #[cfg(test)]
@@ -608,5 +837,121 @@ mod tests {
             msg.contains("header CRC") || msg.contains("header crc"),
             "expected header CRC error, got: {msg}"
         );
+    }
+
+    // ================================================================
+    // ValueLog Manager tests
+    // ================================================================
+
+    use std::io::Write;
+
+    fn make_test_options() -> ValueSeparationOptions {
+        ValueSeparationOptions {
+            enabled: true,
+            min_value_size: 4,
+            max_value_size: 1 << 20,
+            max_vlog_file_size: 1 << 20,
+            gc_threshold_ratio: 0.5,
+            max_open_vlog_files: 4,
+        }
+    }
+
+    #[test]
+    fn test_vlog_manager_open_scans_existing_files() {
+        let dir = tempfile::tempdir().unwrap();
+        // Create a couple of vLog files out-of-band.
+        for id in [3u32, 7, 12] {
+            let path = dir.path().join(format!("{}.vlog", id));
+            let mut f = std::fs::File::create(&path).unwrap();
+            let mut buf = Vec::new();
+            VlogFileHeader {
+                magic: VLOG_MAGIC,
+                version: 1,
+                reserved: [0u8; 10],
+            }
+            .encode(&mut buf);
+            f.write_all(&buf).unwrap();
+        }
+
+        let vlog = ValueLog::open(dir.path(), make_test_options()).unwrap();
+        assert_eq!(vlog.next_file_id(), 13); // 12 + 1
+    }
+
+    #[test]
+    fn test_vlog_manager_reader_cache_and_read() {
+        let dir = tempfile::tempdir().unwrap();
+        let vlog = ValueLog::open(dir.path(), make_test_options()).unwrap();
+        let file_id = vlog.next_file_id();
+
+        // Write an entry manually.
+        let key = b"hello";
+        let value = b"world";
+        let path = vlog.path_of_file(file_id);
+        {
+            let mut writer = ValueLogWriter::create(path.clone(), file_id).unwrap();
+            writer.append(key, value).unwrap();
+            writer.close().unwrap();
+        }
+
+        // Read back via manager.
+        let ptr = ValuePointer {
+            file_id,
+            offset: VlogFileHeader::SIZE as u64,
+            size: VlogEntryHeader::compute_entry_size(key.len(), value.len()).unwrap() as u32,
+        };
+        let got = vlog.read(&ptr, key).unwrap();
+        assert_eq!(got.as_ref(), value);
+
+        // Cached reader is returned on second request.
+        let h1 = vlog.get_reader(file_id).unwrap();
+        let h2 = vlog.get_reader(file_id).unwrap();
+        assert!(Arc::ptr_eq(&h1, &h2));
+    }
+
+    #[test]
+    fn test_vlog_manager_reference_tracking() {
+        let refs = VlogReferences::new();
+        refs.register(1, &[10, 20]);
+        refs.register(2, &[20, 30]);
+
+        let mut r1 = refs.get_sst_references(1).unwrap();
+        r1.sort();
+        assert_eq!(r1, vec![10, 20]);
+
+        let mut r20 = refs.get_ssts_referencing(20).unwrap();
+        r20.sort();
+        assert_eq!(r20, vec![1, 2]);
+
+        let mut removed = refs.unregister(1);
+        removed.sort();
+        assert_eq!(removed, vec![10, 20]);
+        assert!(refs.get_sst_references(1).is_none());
+        assert_eq!(refs.get_ssts_referencing(10), None);
+        // SST 2 still references 20.
+        assert_eq!(refs.get_ssts_referencing(20).unwrap(), vec![2]);
+    }
+
+    #[test]
+    fn test_vlog_manager_remove_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let vlog = ValueLog::open(dir.path(), make_test_options()).unwrap();
+        let file_id = vlog.next_file_id();
+
+        let path = vlog.path_of_file(file_id);
+        {
+            let mut f = std::fs::File::create(&path).unwrap();
+            let mut buf = Vec::new();
+            VlogFileHeader {
+                magic: VLOG_MAGIC,
+                version: 1,
+                reserved: [0u8; 10],
+            }
+            .encode(&mut buf);
+            f.write_all(&buf).unwrap();
+        }
+        assert!(path.exists());
+
+        vlog.remove_file(file_id).unwrap();
+        assert!(!path.exists());
     }
 }

--- a/mini-lsm-starter/src/vlog/mod.rs
+++ b/mini-lsm-starter/src/vlog/mod.rs
@@ -492,7 +492,7 @@ impl ValueLog {
         }
         {
             let mut pending = self.pending_deletions.lock();
-            *pending = remaining;
+            pending.extend(remaining);
         }
         match first_err {
             Some(e) => Err(e),

--- a/mini-lsm-starter/src/vlog/mod.rs
+++ b/mini-lsm-starter/src/vlog/mod.rs
@@ -466,10 +466,13 @@ impl ValueLog {
     /// Attempt to delete any pending vLog files that are no longer
     /// referenced by any SST.
     pub fn reclaim_pending_deletions(&self) -> Result<usize> {
-        let to_process: Vec<u32> = {
+        let mut to_process: Vec<u32> = {
             let mut pending = self.pending_deletions.lock();
             std::mem::take(&mut *pending)
         };
+        to_process.sort_unstable();
+        to_process.dedup();
+
         let mut remaining = Vec::new();
         let mut deleted = 0usize;
         let mut first_err = None;
@@ -482,7 +485,9 @@ impl ValueLog {
                 match self.remove_file(file_id) {
                     Ok(()) => deleted += 1,
                     Err(e) => {
-                        first_err = Some(e);
+                        if first_err.is_none() {
+                            first_err = Some(e);
+                        }
                         remaining.push(file_id);
                     }
                 }

--- a/mini-lsm-starter/src/vlog/mod.rs
+++ b/mini-lsm-starter/src/vlog/mod.rs
@@ -241,11 +241,6 @@ pub struct VlogEntry {
 // ValueLog Manager (Phase 2 — SSTable Integration)
 // =============================================================================
 
-/// Handle to a cached vLog reader with shared ownership.
-pub struct ValueLogReaderHandle {
-    pub reader: ValueLogReader,
-}
-
 /// Tracks which vLog files are referenced by each SST.
 pub struct VlogReferences {
     /// SST id -> set of vLog file ids it references.
@@ -326,7 +321,7 @@ pub struct ValueLog {
     /// Monotonically increasing file id for the *next* vLog file to create.
     next_file_id: AtomicU32,
     /// Cache of open readers keyed by `file_id`.
-    readers: Cache<u32, Arc<ValueLogReaderHandle>>,
+    readers: Cache<u32, Arc<ValueLogReader>>,
     /// Tracks which SSTs reference which vLog files.
     pub references: VlogReferences,
     /// Pending vLog file ids waiting for GC reclaim (Phase 3).
@@ -344,10 +339,11 @@ impl ValueLog {
         for entry in std::fs::read_dir(&path)? {
             let entry = entry?;
             let name = entry.file_name();
-            let name = name.to_string_lossy();
-            if let Some(stem) = name.strip_suffix(".vlog") {
-                if let Ok(id) = stem.parse::<u32>() {
-                    max_id = Some(max_id.map_or(id, |m| std::cmp::max(m, id)));
+            if let Some(name) = name.to_str() {
+                if let Some(stem) = name.strip_suffix(".vlog") {
+                    if let Ok(id) = stem.parse::<u32>() {
+                        max_id = Some(max_id.map_or(id, |m| std::cmp::max(m, id)));
+                    }
                 }
             }
         }
@@ -375,12 +371,12 @@ impl ValueLog {
     }
 
     /// Get a cached reader for `file_id`, opening it on cache miss.
-    pub fn get_reader(&self, file_id: u32) -> Result<Arc<ValueLogReaderHandle>> {
+    pub fn get_reader(&self, file_id: u32) -> Result<Arc<ValueLogReader>> {
         let path = self.path_of_file(file_id);
         self.readers
             .try_get_with(file_id, || {
-                let reader = ValueLogReader::open(path.clone())?;
-                Ok::<_, anyhow::Error>(Arc::new(ValueLogReaderHandle { reader }))
+                let reader = ValueLogReader::open(path)?;
+                Ok::<_, anyhow::Error>(Arc::new(reader))
             })
             .map_err(|e| anyhow!("failed to open vlog reader {}: {}", file_id, e))
     }
@@ -388,8 +384,8 @@ impl ValueLog {
     /// Read the value at `ptr`, verifying that the stored key matches
     /// `expected_key`.
     pub fn read(&self, ptr: &ValuePointer, expected_key: &[u8]) -> Result<Bytes> {
-        let handle = self.get_reader(ptr.file_id)?;
-        let entry = handle.reader.read_entry(ptr.offset, ptr.size)?;
+        let reader = self.get_reader(ptr.file_id)?;
+        let entry = reader.read_entry(ptr.offset, ptr.size)?;
         if entry.key != expected_key {
             return Err(anyhow!(
                 "vlog key mismatch: expected {:?}, got {:?}",


### PR DESCRIPTION
## Summary

Implements the `ValueLog` manager for Phase 2 (SSTable integration) of the key-value separation RFC.

## Changes

### New Types
- `ValueLogReaderHandle` — wrapper around `ValueLogReader` for the `moka` cache
- `VlogReferences` — bidirectional reference tracking (`SST id ↔ vLog file id`)
- `ValueLog` — manager struct owning reader cache, file rotation, and ref tracking

### Key Methods
- `open(path, options)` — scans existing `*.vlog` files, sets `next_file_id`
- `get_reader(file_id)` — `moka::sync::Cache` with `try_get_with`
- `read(ptr, expected_key)` — cached read + key verification
- `register_sst_references(sst_id, vlog_ids)` / `unregister_sst_references(sst_id)`
- `get_ssts_referencing(vlog_id)` — for GC safety checks
- `remove_file(file_id)` — invalidate cache + delete disk file
- `schedule_deletion(file_id)` / `reclaim_pending_deletions()` — Phase 3 GC placeholders

### Tests
- `test_vlog_manager_open_scans_existing_files`
- `test_vlog_manager_reader_cache_and_read`
- `test_vlog_manager_reference_tracking`
- `test_vlog_manager_remove_file`

## Verification
- [x] `cargo fmt --check` passes
- [x] `cargo clippy` clean
- [x] All 68 starter tests pass

Relates to key-value separation RFC Phase 2.