### PR TITLE
feat: add vLog value cache for point-get optimization

### DIFF
--- a/docs/bench-report-vlog.md
+++ b/docs/bench-report-vlog.md
@@ -164,7 +164,7 @@ once at flush time, not rewritten during compaction).
 | Bottleneck | Impact | Potential Fix |
 |------------|--------|---------------|
 | Double I/O for point-gets (SST + vLog) | 2x latency (uncached), 1.3x (cached) | Value cache (implemented); mmap for vLog files |
-| No vLog value caching | Repeated reads hit disk | LRU cache for hot vLog values |
+| vLog value caching (implemented) | Configurable via `max_value_cache_entries` | Default off; set to working set size for hot keys |
 | Scan reads vLog entries one-at-a-time | Sequential but serial | Batch prefetch next N entries |
 
 ### Compaction

--- a/docs/bench-report-vlog.md
+++ b/docs/bench-report-vlog.md
@@ -23,17 +23,19 @@ Run: `cargo bench --package mini-lsm-starter --bench vlog_benchmarks`
 
 ## Results Summary
 
-| Metric | Inline | vLog | Delta | Notes |
-|--------|--------|------|-------|-------|
-| Compaction time | 98ms | 3.0ms | **33x faster** | 5000 entries @ 16KB |
-| Compaction SST rewrite | 78.4MB | 0.1MB | **780x less** | Keys+ptrs vs full values |
-| Full scan | 19.6ms | 13.0ms | **34% faster** | Smaller SSTs = less I/O |
-| Point-get | 1.5us | 3.0us | **2x slower** | Extra vLog seek |
-| Write throughput (1KB) | 950us | 1000us | ~5% slower | Per 1000 entries |
-| Write throughput (4KB) | 1000us | 1183us | ~18% slower | |
-| Write throughput (16KB) | 1160us | 1404us | ~21% slower | |
-| Write throughput (64KB) | 3562us | 4737us | ~33% slower | |
-| On-disk ratio (post-compact) | 1.00x | 1.00x | Same | Single round |
+| Metric | Inline | vLog | vLog+Cache | Delta (no cache) | Delta (cached) |
+|--------|--------|------|------------|------------------|----------------|
+| Compaction time | 98ms | 3.0ms | — | **33x faster** | — |
+| Compaction SST rewrite | 78.4MB | 0.1MB | — | **780x less** | — |
+| Full scan | 19.6ms | 13.0ms | — | **34% faster** | — |
+| Point-get | 2.14us | 4.21us | **2.76us** | 2x slower | **29% slower** |
+| Write throughput (1KB) | 950us | 1000us | — | ~5% slower | — |
+| Write throughput (4KB) | 1000us | 1183us | — | ~18% slower | — |
+| Write throughput (16KB) | 1160us | 1404us | — | ~21% slower | — |
+| Write throughput (64KB) | 3562us | 4737us | — | ~33% slower | — |
+| On-disk ratio (post-compact) | 1.00x | 1.00x | — | Same | — |
+
+Value cache (10K entries): 99.2% hit rate, reduces vLog point-get latency by 34%.
 
 ---
 
@@ -87,18 +89,24 @@ GC'd separately. This is the core write-amplification reduction.
 Measures `get()` for random keys after full compaction (clean LSM state).
 
 ```text
-read_point_get/inline    time: [1.4396 us 1.4596 us 1.4646 us]
-read_point_get/vlog      time: [2.8820 us 2.9629 us 2.9831 us]
+read_point_get/inline       time: [2.1229 us 2.1350 us 2.1381 us]
+read_point_get/vlog         time: [4.2050 us 4.2070 us 4.2075 us]
+read_point_get/vlog_cached  time: [2.7395 us 2.7572 us 2.8277 us]  (99.2% hit rate)
 ```
 
 **Analysis**: vLog point-gets require two I/O operations:
-1. Read the SST block to get the `ValuePointer` (~1.5us, same as inline)
-2. Read the vLog file at the pointer offset (~1.5us additional)
+1. Read the SST block to get the `ValuePointer` (~2us, same as inline)
+2. Read the vLog file at the pointer offset (~2us additional)
 
-The extra seek is the cost of separation. Mitigations:
+With the value cache (10K entries, `max_value_cache_entries`), repeated reads
+to the same keys are served from memory — 99.2% hit rate reduces latency from
+4.2us to 2.8us (34% improvement). The remaining 29% overhead vs inline is the
+SST lookup + cache hash probe.
+
+Mitigations:
+- **Value cache** (new): LRU cache keyed by `(file_id, offset)`, configurable via `max_value_cache_entries`
 - vLog reader cache (moka) avoids re-opening files
 - Sequential vLog layout benefits from OS readahead
-- Point-get latency is dominated by the LSM tree lookup, not the vLog read
 
 ### 4. Full Scan Throughput
 
@@ -155,7 +163,7 @@ once at flush time, not rewritten during compaction).
 
 | Bottleneck | Impact | Potential Fix |
 |------------|--------|---------------|
-| Double I/O for point-gets (SST + vLog) | 2x latency | Prefetch vLog entries on SST read; value cache |
+| Double I/O for point-gets (SST + vLog) | 2x latency (uncached), 1.3x (cached) | Value cache (implemented); mmap for vLog files |
 | No vLog value caching | Repeated reads hit disk | LRU cache for hot vLog values |
 | Scan reads vLog entries one-at-a-time | Sequential but serial | Batch prefetch next N entries |
 

--- a/mini-lsm-starter/benches/vlog_benchmarks.rs
+++ b/mini-lsm-starter/benches/vlog_benchmarks.rs
@@ -107,6 +107,28 @@ fn dir_size(path: &Path, extension: &str) -> u64 {
         .sum()
 }
 
+fn make_options_with_cache(min_value_size: usize, cache_entries: u64) -> LsmStorageOptions {
+    LsmStorageOptions {
+        block_size: 4096,
+        target_sst_size: 2 << 20,
+        num_memtable_limit: 2,
+        compaction_options: CompactionOptions::Leveled(LeveledCompactionOptions {
+            level0_file_num_compaction_trigger: 1000,
+            max_levels: 3,
+            base_level_size_mb: 1,
+            level_size_multiplier: 2,
+        }),
+        enable_wal: false,
+        serializable: false,
+        value_separation: Some(ValueSeparationOptions {
+            enabled: true,
+            min_value_size,
+            max_value_cache_entries: cache_entries,
+            ..Default::default()
+        }),
+    }
+}
+
 fn setup_instance(
     vlog_enabled: bool,
     min_value_size: usize,
@@ -260,6 +282,43 @@ fn bench_read_point_get(c: &mut Criterion) {
                 i += 1;
             })
         });
+
+        lsm.close().unwrap();
+        drop(dir);
+    }
+
+    // vlog with value cache (10K entries)
+    {
+        let dir = tempfile::tempdir().unwrap();
+        let options = make_options_with_cache(16, 10_000);
+        let lsm = MiniLsm::open(dir.path(), options).unwrap();
+        load_data(&lsm, num_entries, value_size);
+        lsm.force_full_compaction().unwrap();
+
+        let keys: Vec<Vec<u8>> = (0..1000)
+            .map(|i| format!("key{:08}", i).into_bytes())
+            .collect();
+
+        group.bench_function("vlog_cached", |b| {
+            let mut i = 0usize;
+            b.iter(|| {
+                let result = lsm.get(&keys[i % keys.len()]).unwrap();
+                black_box(result);
+                i += 1;
+            })
+        });
+
+        let stats = lsm.vlog_stats().unwrap();
+        eprintln!(
+            "[vlog_cached] cache_hits={} cache_misses={} hit_rate={:.1}%",
+            stats.cache_hits,
+            stats.cache_misses,
+            if stats.cache_hits + stats.cache_misses > 0 {
+                stats.cache_hits as f64 / (stats.cache_hits + stats.cache_misses) as f64 * 100.0
+            } else {
+                0.0
+            }
+        );
 
         lsm.close().unwrap();
         drop(dir);

--- a/mini-lsm-starter/src/vlog/gc.rs
+++ b/mini-lsm-starter/src/vlog/gc.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 use anyhow::{Ok, Result};
+use bytes::Bytes;
 
 use crate::lsm_storage::LsmStorageInner;
 use crate::vlog::builder::ValueLogWriter;
@@ -133,7 +134,7 @@ impl<'a> GarbageCollector<'a> {
         let compact_res = (|| -> Result<GcResult> {
             let mut writer = ValueLogWriter::create(new_path.clone(), new_file_id)?;
 
-            let mut rewrites: Vec<(Vec<u8>, ValuePointer, ValuePointer)> = Vec::new();
+            let mut rewrites: Vec<(Vec<u8>, Vec<u8>, ValuePointer, ValuePointer)> = Vec::new();
 
             for live_ref in &analysis.live_entries {
                 let (key, value) = self.vlog.read_entry(&live_ref.ptr)?;
@@ -143,7 +144,7 @@ impl<'a> GarbageCollector<'a> {
                     offset: writer.offset() - bytes_written as u64,
                     size: bytes_written as u32,
                 };
-                rewrites.push((key, live_ref.ptr, new_ptr));
+                rewrites.push((key, value, live_ref.ptr, new_ptr));
             }
 
             // Fsync the new vLog before binding pointers into the LSM tree
@@ -157,7 +158,7 @@ impl<'a> GarbageCollector<'a> {
             // Phase 2: Batch CAS all keys under a single lock acquisition
             let mut batch: Vec<(Vec<u8>, Vec<u8>, KvKind, Vec<u8>, KvKind)> =
                 Vec::with_capacity(rewrites.len());
-            for (key, old_ptr, new_ptr) in &rewrites {
+            for (key, _value, old_ptr, new_ptr) in &rewrites {
                 let mut old_buf = Vec::with_capacity(1 + ValuePointer::encoded_size());
                 old_buf.push(KvKind::ValuePointer as u8);
                 old_ptr.encode(&mut old_buf);
@@ -175,6 +176,17 @@ impl<'a> GarbageCollector<'a> {
             }
             let cas_results = self.inner.compare_and_set_batch_with_kind(&batch)?;
             let cas_failures = cas_results.iter().filter(|&&r| !r).count();
+
+            // Cache successfully rewritten entries so subsequent reads avoid disk.
+            if self.vlog.options.max_value_cache_entries > 0 {
+                for (i, succeeded) in cas_results.iter().enumerate() {
+                    if *succeeded {
+                        let (_key, value, _old_ptr, new_ptr) = &rewrites[i];
+                        self.vlog
+                            .insert_cache(*new_ptr, Bytes::copy_from_slice(value));
+                    }
+                }
+            }
 
             // Always schedule the old file for deletion. Concurrent writes during GC
             // go to the memtable (not the old vLog), so the old file has no live

--- a/mini-lsm-starter/src/vlog/gc.rs
+++ b/mini-lsm-starter/src/vlog/gc.rs
@@ -134,7 +134,9 @@ impl<'a> GarbageCollector<'a> {
         let compact_res = (|| -> Result<GcResult> {
             let mut writer = ValueLogWriter::create(new_path.clone(), new_file_id)?;
 
-            let mut rewrites: Vec<(Vec<u8>, Bytes, ValuePointer, ValuePointer)> = Vec::new();
+            let cache_enabled = self.vlog.options.max_value_cache_entries > 0;
+            let mut rewrites: Vec<(Vec<u8>, Option<Bytes>, ValuePointer, ValuePointer)> =
+                Vec::new();
 
             for live_ref in &analysis.live_entries {
                 let (key, value) = self.vlog.read_entry(&live_ref.ptr)?;
@@ -144,7 +146,12 @@ impl<'a> GarbageCollector<'a> {
                     offset: writer.offset() - bytes_written as u64,
                     size: bytes_written as u32,
                 };
-                rewrites.push((key, Bytes::from(value), live_ref.ptr, new_ptr));
+                let cached_value = if cache_enabled {
+                    Some(Bytes::from(value))
+                } else {
+                    None
+                };
+                rewrites.push((key, cached_value, live_ref.ptr, new_ptr));
             }
 
             // Fsync the new vLog before binding pointers into the LSM tree
@@ -180,7 +187,9 @@ impl<'a> GarbageCollector<'a> {
             // Cache successfully rewritten entries so subsequent reads avoid disk.
             for (succeeded, (_key, value, _old_ptr, new_ptr)) in cas_results.iter().zip(&rewrites) {
                 if *succeeded {
-                    self.vlog.insert_cache(*new_ptr, value.clone());
+                    if let Some(val) = value {
+                        self.vlog.insert_cache(*new_ptr, val.clone());
+                    }
                 }
             }
 

--- a/mini-lsm-starter/src/vlog/gc.rs
+++ b/mini-lsm-starter/src/vlog/gc.rs
@@ -134,7 +134,7 @@ impl<'a> GarbageCollector<'a> {
         let compact_res = (|| -> Result<GcResult> {
             let mut writer = ValueLogWriter::create(new_path.clone(), new_file_id)?;
 
-            let mut rewrites: Vec<(Vec<u8>, Vec<u8>, ValuePointer, ValuePointer)> = Vec::new();
+            let mut rewrites: Vec<(Vec<u8>, Bytes, ValuePointer, ValuePointer)> = Vec::new();
 
             for live_ref in &analysis.live_entries {
                 let (key, value) = self.vlog.read_entry(&live_ref.ptr)?;
@@ -144,7 +144,7 @@ impl<'a> GarbageCollector<'a> {
                     offset: writer.offset() - bytes_written as u64,
                     size: bytes_written as u32,
                 };
-                rewrites.push((key, value, live_ref.ptr, new_ptr));
+                rewrites.push((key, Bytes::from(value), live_ref.ptr, new_ptr));
             }
 
             // Fsync the new vLog before binding pointers into the LSM tree
@@ -178,13 +178,9 @@ impl<'a> GarbageCollector<'a> {
             let cas_failures = cas_results.iter().filter(|&&r| !r).count();
 
             // Cache successfully rewritten entries so subsequent reads avoid disk.
-            if self.vlog.options.max_value_cache_entries > 0 {
-                for (i, succeeded) in cas_results.iter().enumerate() {
-                    if *succeeded {
-                        let (_key, value, _old_ptr, new_ptr) = &rewrites[i];
-                        self.vlog
-                            .insert_cache(*new_ptr, Bytes::copy_from_slice(value));
-                    }
+            for (succeeded, (_key, value, _old_ptr, new_ptr)) in cas_results.iter().zip(&rewrites) {
+                if *succeeded {
+                    self.vlog.insert_cache(*new_ptr, value.clone());
                 }
             }
 

--- a/mini-lsm-starter/src/vlog/mod.rs
+++ b/mini-lsm-starter/src/vlog/mod.rs
@@ -120,6 +120,8 @@ pub struct ValueSeparationOptions {
     pub gc_threshold_ratio: f64,
     /// Maximum number of vLog files to keep open
     pub max_open_vlog_files: usize,
+    /// Maximum number of entries in the value cache. 0 disables caching.
+    pub max_value_cache_entries: u64,
 }
 
 impl Default for ValueSeparationOptions {
@@ -131,6 +133,7 @@ impl Default for ValueSeparationOptions {
             max_vlog_file_size: 64 << 20,
             gc_threshold_ratio: 0.5,
             max_open_vlog_files: 64,
+            max_value_cache_entries: 0,
         }
     }
 }
@@ -148,6 +151,10 @@ pub struct ValueLogStats {
     pub gc_bytes_rewritten: u64,
     /// Cumulative vLog files processed by GC since startup.
     pub gc_files_processed: u64,
+    /// Cumulative value cache hits since startup.
+    pub cache_hits: u64,
+    /// Cumulative value cache misses since startup.
+    pub cache_misses: u64,
 }
 
 /// Value log file header (first 16 bytes of each vLog file).
@@ -354,6 +361,9 @@ pub struct ValueLog {
     next_file_id: AtomicU32,
     /// Cache of open readers keyed by `file_id`.
     readers: Cache<u32, Arc<ValueLogReader>>,
+    /// Cache of vLog values keyed by `(file_id, offset)`.
+    /// Avoids repeated `pread` syscalls for hot keys.
+    value_cache: Cache<(u32, u64), Bytes>,
     /// Tracks which SSTs reference which vLog files.
     pub references: VlogReferences,
     /// Pending vLog files waiting for GC reclaim.
@@ -367,6 +377,10 @@ pub struct ValueLog {
     gc_bytes_rewritten: AtomicU64,
     /// Cumulative vLog files processed by GC since startup.
     gc_files_processed: AtomicU64,
+    /// Cumulative value cache hits since startup.
+    cache_hits: AtomicU64,
+    /// Cumulative value cache misses since startup.
+    cache_misses: AtomicU64,
 }
 
 impl ValueLog {
@@ -397,18 +411,22 @@ impl ValueLog {
         }
 
         let readers = Cache::new(options.max_open_vlog_files as u64);
+        let value_cache = Cache::new(options.max_value_cache_entries.max(1));
 
         Ok(Self {
             path,
             options,
             next_file_id: AtomicU32::new(max_id.map_or(0, |id| id + 1)),
             readers,
+            value_cache,
             references: VlogReferences::new(),
             pending_deletions: Mutex::new(Vec::new()),
             gc_locks: Mutex::new(HashSet::new()),
             gc_entries_rewritten: AtomicU64::new(0),
             gc_bytes_rewritten: AtomicU64::new(0),
             gc_files_processed: AtomicU64::new(0),
+            cache_hits: AtomicU64::new(0),
+            cache_misses: AtomicU64::new(0),
         })
     }
 
@@ -434,18 +452,40 @@ impl ValueLog {
     }
 
     /// Read the value at `ptr`, verifying that the stored key matches
-    /// `expected_key`.
+    /// `expected_key`. Returns from the value cache on hit; on miss, reads
+    /// from disk and inserts into the cache.
     pub fn read(&self, ptr: &ValuePointer, expected_key: &[u8]) -> Result<Bytes> {
-        let reader = self.get_reader(ptr.file_id)?;
-        let entry = reader.read_entry(ptr.offset, ptr.size)?;
-        if entry.key != expected_key {
-            return Err(anyhow!(
-                "vlog key mismatch: expected {:?}, got {:?}",
-                expected_key,
-                entry.key
-            ));
+        if self.options.max_value_cache_entries > 0 {
+            let cache_key = (ptr.file_id, ptr.offset);
+            if let Some(cached) = self.value_cache.get(&cache_key) {
+                self.cache_hits.fetch_add(1, Ordering::Relaxed);
+                return Ok(cached);
+            }
+            self.cache_misses.fetch_add(1, Ordering::Relaxed);
+            let reader = self.get_reader(ptr.file_id)?;
+            let entry = reader.read_entry(ptr.offset, ptr.size)?;
+            if entry.key != expected_key {
+                return Err(anyhow!(
+                    "vlog key mismatch: expected {:?}, got {:?}",
+                    expected_key,
+                    entry.key
+                ));
+            }
+            let value = Bytes::from(entry.value);
+            self.value_cache.insert(cache_key, value.clone());
+            Ok(value)
+        } else {
+            let reader = self.get_reader(ptr.file_id)?;
+            let entry = reader.read_entry(ptr.offset, ptr.size)?;
+            if entry.key != expected_key {
+                return Err(anyhow!(
+                    "vlog key mismatch: expected {:?}, got {:?}",
+                    expected_key,
+                    entry.key
+                ));
+            }
+            Ok(Bytes::from(entry.value))
         }
-        Ok(Bytes::from(entry.value))
     }
 
     /// Read a full vLog entry (key, value) at the given pointer.
@@ -485,6 +525,10 @@ impl ValueLog {
             return Err(e.into());
         }
         self.readers.invalidate(&file_id);
+        // Invalidate all cached values from this file.
+        let _ = self
+            .value_cache
+            .invalidate_entries_if(move |k, _| k.0 == file_id);
         Ok(())
     }
 
@@ -636,6 +680,8 @@ impl ValueLog {
             gc_entries_rewritten: self.gc_entries_rewritten.load(Ordering::Relaxed),
             gc_bytes_rewritten: self.gc_bytes_rewritten.load(Ordering::Relaxed),
             gc_files_processed: self.gc_files_processed.load(Ordering::Relaxed),
+            cache_hits: self.cache_hits.load(Ordering::Relaxed),
+            cache_misses: self.cache_misses.load(Ordering::Relaxed),
         })
     }
 }
@@ -1024,6 +1070,7 @@ mod tests {
             max_vlog_file_size: 1 << 20,
             gc_threshold_ratio: 0.5,
             max_open_vlog_files: 4,
+            max_value_cache_entries: 0,
         }
     }
 

--- a/mini-lsm-starter/src/vlog/mod.rs
+++ b/mini-lsm-starter/src/vlog/mod.rs
@@ -451,41 +451,43 @@ impl ValueLog {
             .map_err(|e| anyhow!("failed to open vlog reader {}: {}", file_id, e))
     }
 
+    /// Insert a value into the cache. Used by GC after rewriting entries.
+    pub fn insert_cache(&self, ptr: ValuePointer, value: Bytes) {
+        if self.options.max_value_cache_entries > 0 {
+            self.value_cache.insert((ptr.file_id, ptr.offset), value);
+        }
+    }
+
     /// Read the value at `ptr`, verifying that the stored key matches
     /// `expected_key`. Returns from the value cache on hit; on miss, reads
     /// from disk and inserts into the cache.
     pub fn read(&self, ptr: &ValuePointer, expected_key: &[u8]) -> Result<Bytes> {
-        if self.options.max_value_cache_entries > 0 {
-            let cache_key = (ptr.file_id, ptr.offset);
+        let cache_enabled = self.options.max_value_cache_entries > 0;
+        let cache_key = (ptr.file_id, ptr.offset);
+
+        if cache_enabled {
             if let Some(cached) = self.value_cache.get(&cache_key) {
                 self.cache_hits.fetch_add(1, Ordering::Relaxed);
                 return Ok(cached);
             }
             self.cache_misses.fetch_add(1, Ordering::Relaxed);
-            let reader = self.get_reader(ptr.file_id)?;
-            let entry = reader.read_entry(ptr.offset, ptr.size)?;
-            if entry.key != expected_key {
-                return Err(anyhow!(
-                    "vlog key mismatch: expected {:?}, got {:?}",
-                    expected_key,
-                    entry.key
-                ));
-            }
-            let value = Bytes::from(entry.value);
-            self.value_cache.insert(cache_key, value.clone());
-            Ok(value)
-        } else {
-            let reader = self.get_reader(ptr.file_id)?;
-            let entry = reader.read_entry(ptr.offset, ptr.size)?;
-            if entry.key != expected_key {
-                return Err(anyhow!(
-                    "vlog key mismatch: expected {:?}, got {:?}",
-                    expected_key,
-                    entry.key
-                ));
-            }
-            Ok(Bytes::from(entry.value))
         }
+
+        let reader = self.get_reader(ptr.file_id)?;
+        let entry = reader.read_entry(ptr.offset, ptr.size)?;
+        if entry.key != expected_key {
+            return Err(anyhow!(
+                "vlog key mismatch: expected {:?}, got {:?}",
+                expected_key,
+                entry.key
+            ));
+        }
+        let value = Bytes::from(entry.value);
+
+        if cache_enabled {
+            self.value_cache.insert(cache_key, value.clone());
+        }
+        Ok(value)
     }
 
     /// Read a full vLog entry (key, value) at the given pointer.

--- a/mini-lsm-starter/src/vlog/mod.rs
+++ b/mini-lsm-starter/src/vlog/mod.rs
@@ -362,8 +362,8 @@ pub struct ValueLog {
     /// Cache of open readers keyed by `file_id`.
     readers: Cache<u32, Arc<ValueLogReader>>,
     /// Cache of vLog values keyed by `(file_id, offset)`.
-    /// Avoids repeated `pread` syscalls for hot keys.
-    value_cache: Cache<(u32, u64), Bytes>,
+    /// Avoids repeated `pread` syscalls for hot keys. `None` when disabled.
+    value_cache: Option<Cache<(u32, u64), Bytes>>,
     /// Tracks which SSTs reference which vLog files.
     pub references: VlogReferences,
     /// Pending vLog files waiting for GC reclaim.
@@ -411,7 +411,11 @@ impl ValueLog {
         }
 
         let readers = Cache::new(options.max_open_vlog_files as u64);
-        let value_cache = Cache::new(options.max_value_cache_entries.max(1));
+        let value_cache = if options.max_value_cache_entries > 0 {
+            Some(Cache::new(options.max_value_cache_entries))
+        } else {
+            None
+        };
 
         Ok(Self {
             path,
@@ -453,8 +457,8 @@ impl ValueLog {
 
     /// Insert a value into the cache. Used by GC after rewriting entries.
     pub fn insert_cache(&self, ptr: ValuePointer, value: Bytes) {
-        if self.options.max_value_cache_entries > 0 {
-            self.value_cache.insert((ptr.file_id, ptr.offset), value);
+        if let Some(ref cache) = self.value_cache {
+            cache.insert((ptr.file_id, ptr.offset), value);
         }
     }
 
@@ -462,11 +466,10 @@ impl ValueLog {
     /// `expected_key`. Returns from the value cache on hit; on miss, reads
     /// from disk and inserts into the cache.
     pub fn read(&self, ptr: &ValuePointer, expected_key: &[u8]) -> Result<Bytes> {
-        let cache_enabled = self.options.max_value_cache_entries > 0;
         let cache_key = (ptr.file_id, ptr.offset);
 
-        if cache_enabled {
-            if let Some(cached) = self.value_cache.get(&cache_key) {
+        if let Some(ref cache) = self.value_cache {
+            if let Some(cached) = cache.get(&cache_key) {
                 self.cache_hits.fetch_add(1, Ordering::Relaxed);
                 return Ok(cached);
             }
@@ -484,8 +487,8 @@ impl ValueLog {
         }
         let value = Bytes::from(entry.value);
 
-        if cache_enabled {
-            self.value_cache.insert(cache_key, value.clone());
+        if let Some(ref cache) = self.value_cache {
+            cache.insert(cache_key, value.clone());
         }
         Ok(value)
     }
@@ -528,9 +531,9 @@ impl ValueLog {
         }
         self.readers.invalidate(&file_id);
         // Invalidate all cached values from this file.
-        let _ = self
-            .value_cache
-            .invalidate_entries_if(move |k, _| k.0 == file_id);
+        if let Some(ref cache) = self.value_cache {
+            let _ = cache.invalidate_entries_if(move |k, _| k.0 == file_id);
+        }
         Ok(())
     }
 

--- a/mini-lsm-starter/src/vlog_integration_tests.rs
+++ b/mini-lsm-starter/src/vlog_integration_tests.rs
@@ -1180,3 +1180,107 @@ fn test_vlog_stats_api() {
         Some(Bytes::from(vec![b'd'; 64]))
     );
 }
+
+#[test]
+fn test_value_cache_hit_miss() {
+    let dir = tempfile::tempdir().unwrap();
+    let options = LsmStorageOptions {
+        block_size: 256,
+        target_sst_size: 1 << 20,
+        num_memtable_limit: 2,
+        compaction_options: CompactionOptions::NoCompaction,
+        enable_wal: false,
+        serializable: false,
+        value_separation: Some(ValueSeparationOptions {
+            enabled: true,
+            min_value_size: 16,
+            max_value_cache_entries: 1000,
+            ..Default::default()
+        }),
+    };
+    let storage = MiniLsm::open(dir.path(), options).unwrap();
+
+    // Write and flush to create vLog entries
+    storage.put(b"key1", &vec![b'a'; 64]).unwrap();
+    storage.put(b"key2", &vec![b'b'; 64]).unwrap();
+    storage
+        .inner
+        .force_freeze_memtable(&storage.inner.state_lock.lock())
+        .unwrap();
+    storage.inner.force_flush_next_imm_memtable().unwrap();
+
+    // First read: cache miss
+    assert_eq!(
+        storage.get(b"key1").unwrap(),
+        Some(Bytes::from(vec![b'a'; 64]))
+    );
+    let stats = storage.vlog_stats().unwrap();
+    assert_eq!(stats.cache_misses, 1);
+    assert_eq!(stats.cache_hits, 0);
+
+    // Second read: cache hit
+    assert_eq!(
+        storage.get(b"key1").unwrap(),
+        Some(Bytes::from(vec![b'a'; 64]))
+    );
+    let stats = storage.vlog_stats().unwrap();
+    assert_eq!(stats.cache_misses, 1);
+    assert_eq!(stats.cache_hits, 1);
+
+    // Different key: cache miss
+    assert_eq!(
+        storage.get(b"key2").unwrap(),
+        Some(Bytes::from(vec![b'b'; 64]))
+    );
+    let stats = storage.vlog_stats().unwrap();
+    assert_eq!(stats.cache_misses, 2);
+    assert_eq!(stats.cache_hits, 1);
+
+    // Re-read key2: cache hit
+    assert_eq!(
+        storage.get(b"key2").unwrap(),
+        Some(Bytes::from(vec![b'b'; 64]))
+    );
+    let stats = storage.vlog_stats().unwrap();
+    assert_eq!(stats.cache_misses, 2);
+    assert_eq!(stats.cache_hits, 2);
+}
+
+#[test]
+fn test_value_cache_disabled_by_default() {
+    let dir = tempfile::tempdir().unwrap();
+    let options = LsmStorageOptions {
+        block_size: 256,
+        target_sst_size: 1 << 20,
+        num_memtable_limit: 2,
+        compaction_options: CompactionOptions::NoCompaction,
+        enable_wal: false,
+        serializable: false,
+        value_separation: Some(ValueSeparationOptions {
+            enabled: true,
+            min_value_size: 16,
+            ..Default::default()
+        }),
+    };
+    let storage = MiniLsm::open(dir.path(), options).unwrap();
+
+    storage.put(b"key1", &vec![b'a'; 64]).unwrap();
+    storage
+        .inner
+        .force_freeze_memtable(&storage.inner.state_lock.lock())
+        .unwrap();
+    storage.inner.force_flush_next_imm_memtable().unwrap();
+
+    // Read twice — both should be cache misses (cache disabled)
+    assert_eq!(
+        storage.get(b"key1").unwrap(),
+        Some(Bytes::from(vec![b'a'; 64]))
+    );
+    assert_eq!(
+        storage.get(b"key1").unwrap(),
+        Some(Bytes::from(vec![b'a'; 64]))
+    );
+    let stats = storage.vlog_stats().unwrap();
+    assert_eq!(stats.cache_hits, 0);
+    assert_eq!(stats.cache_misses, 0);
+}


### PR DESCRIPTION
## Summary

- Add moka LRU cache for vLog values keyed by `(file_id, offset)`, configurable via `max_value_cache_entries` in `ValueSeparationOptions` (default: 0 = disabled)
- GC now caches successfully rewritten entries after CAS to avoid cache miss storms post-compaction
- Simplify `read()` to eliminate duplicated logic (single code path with cache gate)
- Add cache hit/miss and cache-disabled-by-default tests
- Add `cache_hits`/`cache_misses` to `ValueLogStats` for runtime monitoring

## Benchmark Results

| Mode | Latency | vs Inline |
|------|---------|-----------|
| inline | 2.14us | baseline |
| vlog (no cache) | 4.21us | 2x slower |
| **vlog_cached** | **2.76us** | **29% slower** |

Cache hit rate: 99.2% (10K cache, 5K keys). Cuts vLog point-get latency by 34%.

## Test plan

- [x] All 96 tests pass (94 existing + 2 new cache tests)
- [x] `test_value_cache_hit_miss` — verifies cache hit/miss counters
- [x] `test_value_cache_disabled_by_default` — verifies cache off with default config

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional in-memory vLog value cache (configurable size) to speed repeated reads.
  * Cache is populated by background GC work when safe and is invalidated when log files are removed.
  * Read path now consults the cache and exposes hit/miss counters.

* **Tests**
  * Integration tests for cache hit/miss behavior and that caching is disabled by default.

* **Benchmarking / Documentation**
  * Updated benchmark report with vLog+Cache results, cached point-get measurements, and hit-rate notes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ben1009/mini-lsm/pull/87?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->