### PR TITLE
fix: raise compaction trigger in vLog tests to prevent background race

### DIFF
--- a/mini-lsm-starter/src/vlog_integration_tests.rs
+++ b/mini-lsm-starter/src/vlog_integration_tests.rs
@@ -34,8 +34,10 @@ fn options_with_vlog_and_compaction(
         block_size,
         target_sst_size,
         num_memtable_limit: 2,
+        // High trigger prevents background compaction from racing with manual
+        // force_full_compaction() calls in tests.
         compaction_options: CompactionOptions::Leveled(LeveledCompactionOptions {
-            level0_file_num_compaction_trigger: 2,
+            level0_file_num_compaction_trigger: 100,
             max_levels: 3,
             base_level_size_mb: 1,
             level_size_multiplier: 2,


### PR DESCRIPTION
## Summary

Fix intermittent CI failure in `test_scan_after_compaction_with_vlog` caused by a race between the background compaction thread and manual `force_full_compaction()` calls.

## Root Cause

`options_with_vlog_and_compaction` used `level0_file_num_compaction_trigger: 2`. With 2 flushes creating 2 L0 SSTs, the background compaction thread could trigger automatically, racing with the test's explicit `force_full_compaction()` call. Both threads try to read/delete the same SST files, causing "No such file or directory" errors.

## Fix

Raised `level0_file_num_compaction_trigger` from 2 to 100 in the test helper. Tests that need manual compaction call `force_full_compaction()` explicitly. Tests that need background compaction already override the trigger (lines 547, 1069).

## Test plan

- [x] All 96 tests pass
- [x] Ran `test_scan_after_compaction_with_vlog` 50 times without failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test stability by adjusting configuration parameters to prevent race conditions during integration testing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ben1009/mini-lsm/pull/88?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->