### PR TITLE
feat: optimize point-get with L1+ binary search, L0 single-pass, and zero-copy inline values

### DIFF
--- a/mini-lsm-starter/benches/vlog_benchmarks.rs
+++ b/mini-lsm-starter/benches/vlog_benchmarks.rs
@@ -101,7 +101,7 @@ fn dir_size(path: &Path, extension: &str) -> u64 {
     };
     entries
         .filter_map(|e| e.ok())
-        .filter(|e| e.path().extension().map_or(false, |ext| ext == extension))
+        .filter(|e| e.path().extension().is_some_and(|ext| ext == extension))
         .filter_map(|e| e.metadata().ok())
         .map(|m| m.len())
         .sum()

--- a/mini-lsm-starter/src/lsm_storage.rs
+++ b/mini-lsm-starter/src/lsm_storage.rs
@@ -640,12 +640,7 @@ impl LsmStorageInner {
         // L1-lmax SSTs: binary search on sorted, non-overlapping sst_ids.
         // At most one SST per level can contain the key, so O(log N) per level.
         for (_, sst_ids) in state.levels.iter() {
-            let idx = sst_ids.partition_point(|id| {
-                state
-                    .sstables
-                    .get(id)
-                    .is_some_and(|s| s.first_key().raw_ref() <= key)
-            });
+            let idx = sst_ids.partition_point(|id| state.sstables[id].first_key().raw_ref() <= key);
 
             if idx == 0 {
                 continue;
@@ -830,12 +825,7 @@ impl LsmStorageInner {
         // L1-lmax SSTs: binary search on sorted, non-overlapping sst_ids.
         // At most one SST per level can contain the key, so O(log N) per level.
         for (_, sst_ids) in state.levels.iter() {
-            let idx = sst_ids.partition_point(|id| {
-                state
-                    .sstables
-                    .get(id)
-                    .is_some_and(|s| s.first_key().raw_ref() <= key)
-            });
+            let idx = sst_ids.partition_point(|id| state.sstables[id].first_key().raw_ref() <= key);
 
             if idx == 0 {
                 continue;

--- a/mini-lsm-starter/src/lsm_storage.rs
+++ b/mini-lsm-starter/src/lsm_storage.rs
@@ -643,7 +643,7 @@ impl LsmStorageInner {
                 state
                     .sstables
                     .get(id)
-                    .is_none_or(|s| s.first_key().as_key_slice() <= KeySlice::from_slice(key))
+                    .is_some_and(|s| s.first_key().raw_ref() <= key)
             });
 
             if idx == 0 {
@@ -832,7 +832,7 @@ impl LsmStorageInner {
                 state
                     .sstables
                     .get(id)
-                    .is_none_or(|s| s.first_key().as_key_slice() <= KeySlice::from_slice(key))
+                    .is_some_and(|s| s.first_key().raw_ref() <= key)
             });
 
             if idx == 0 {

--- a/mini-lsm-starter/src/lsm_storage.rs
+++ b/mini-lsm-starter/src/lsm_storage.rs
@@ -31,6 +31,9 @@ use crate::vlog::{KvKind, ValueLog, ValuePointer, ValueSeparationOptions};
 // TODO: try this one https://github.com/cloudflare/pingora/tree/main/tinyufo with bech later
 pub type BlockCache = moka::sync::Cache<(usize, usize), Arc<Block>>;
 
+/// A CAS entry: (key, old_value, old_kind, new_value, new_kind).
+pub type CasEntry = (Vec<u8>, Vec<u8>, KvKind, Vec<u8>, KvKind);
+
 /// Represents the state of the storage engine.
 #[derive(Clone)]
 pub struct LsmStorageState {
@@ -580,13 +583,13 @@ impl LsmStorageInner {
         let vlog_enabled = self.vlog.is_some();
 
         if vlog_enabled {
-            // Use get_raw to get kind-prefixed value, then resolve
+            // Use get_raw to get kind-prefixed value, then resolve (zero-copy for inline)
             if let Some(raw) = state.memtable.get_raw(key) {
-                return self.resolve_vlog_value(key, &raw);
+                return self.resolve_vlog_value_bytes(key, raw);
             }
             for m in state.imm_memtables.iter() {
                 if let Some(raw) = m.get_raw(key) {
-                    return self.resolve_vlog_value(key, &raw);
+                    return self.resolve_vlog_value_bytes(key, raw);
                 }
             }
         } else {
@@ -606,72 +609,68 @@ impl LsmStorageInner {
             }
         }
 
-        // L0 SSTs, from latest to earliest.
-        let mut sstables_l0 = vec![];
-        state.l0_sstables.iter().for_each(|id| {
+        // L0 SSTs, from latest to earliest. Single-pass: check range + bloom
+        // and create iterator immediately, avoiding intermediate Vec allocation.
+        for id in state.l0_sstables.iter() {
             if let Some(s) = state.sstables.get(id) {
                 if key < s.first_key().raw_ref() || key > s.last_key().raw_ref() {
-                    return;
+                    continue;
                 }
-                if let Some(b) = &s.bloom {
-                    let key_hash = farmhash::hash32(key);
-                    if !b.may_contain(key_hash) {
-                        return;
+                if let Some(b) = &s.bloom
+                    && !b.may_contain(farmhash::hash32(key))
+                {
+                    continue;
+                }
+                let mut s_it =
+                    SsTableIterator::create_and_seek_to_key(s.clone(), KeySlice::from_slice(key))?;
+                if let Some(ref vlog) = self.vlog {
+                    s_it.set_vlog(vlog.clone());
+                }
+                if s_it.is_valid() && s_it.key().raw_ref() == key {
+                    let val = s_it.value();
+                    if val.is_empty() {
+                        return Ok(None);
                     }
+                    return Ok(Some(Bytes::copy_from_slice(val)));
                 }
-
-                sstables_l0.push(s.clone());
-            }
-        });
-
-        for s in sstables_l0.iter() {
-            let mut s_it =
-                SsTableIterator::create_and_seek_to_key(s.clone(), KeySlice::from_slice(key))?;
-            if let Some(ref vlog) = self.vlog {
-                s_it.set_vlog(vlog.clone());
-            }
-            if s_it.is_valid() && s_it.key().raw_ref() == key {
-                let val = s_it.value();
-                if val.is_empty() {
-                    return Ok(None);
-                }
-                return Ok(Some(Bytes::copy_from_slice(val)));
             }
         }
 
-        // L1-lmax SSTs, from latest to earliest.
+        // L1-lmax SSTs: binary search on sorted, non-overlapping sst_ids.
+        // At most one SST per level can contain the key, so O(log N) per level.
         for (_, sst_ids) in state.levels.iter() {
-            let mut sstables = vec![];
-            sst_ids.iter().for_each(|id| {
-                if let Some(s) = state.sstables.get(id) {
-                    if key < s.first_key().raw_ref() || key > s.last_key().raw_ref() {
-                        return;
-                    }
-                    if let Some(b) = &s.bloom {
-                        let key_hash = farmhash::hash32(key);
-                        if !b.may_contain(key_hash) {
-                            return;
-                        }
-                    }
-
-                    sstables.push(s.clone());
-                }
+            let idx = sst_ids.partition_point(|id| {
+                state
+                    .sstables
+                    .get(id)
+                    .is_none_or(|s| s.first_key().as_key_slice() <= KeySlice::from_slice(key))
             });
 
-            let s_it = if let Some(ref vlog) = self.vlog {
-                SstConcatIterator::create_and_seek_to_key_with_vlog(
-                    sstables,
-                    KeySlice::from_slice(key),
-                    vlog.clone(),
-                )?
-            } else {
-                SstConcatIterator::create_and_seek_to_key(sstables, KeySlice::from_slice(key))?
-            };
-            if s_it.is_valid() && s_it.key().raw_ref() == key {
-                if s_it.value().is_empty() {
-                    return Ok(None);
+            if idx == 0 {
+                continue;
+            }
+            let candidate_idx = idx - 1;
+            if let Some(s) = state.sstables.get(&sst_ids[candidate_idx]) {
+                if key < s.first_key().raw_ref() || key > s.last_key().raw_ref() {
+                    continue;
                 }
-                return Ok(Some(Bytes::copy_from_slice(s_it.value())));
+                if let Some(b) = &s.bloom
+                    && !b.may_contain(farmhash::hash32(key))
+                {
+                    continue;
+                }
+                let mut s_it =
+                    SsTableIterator::create_and_seek_to_key(s.clone(), KeySlice::from_slice(key))?;
+                if let Some(ref vlog) = self.vlog {
+                    s_it.set_vlog(vlog.clone());
+                }
+                if s_it.is_valid() && s_it.key().raw_ref() == key {
+                    let val = s_it.value();
+                    if val.is_empty() {
+                        return Ok(None);
+                    }
+                    return Ok(Some(Bytes::copy_from_slice(val)));
+                }
             }
         }
 
@@ -705,6 +704,37 @@ impl LsmStorageInner {
                     Ok(None)
                 } else {
                     Ok(Some(Bytes::copy_from_slice(&prefixed[1..])))
+                }
+            }
+        }
+    }
+
+    /// Resolve a kind-prefixed `Bytes` value from the memtable using zero-copy slicing.
+    /// For inline values, returns `prefixed.slice(1..)` (cheap refcount bump) instead of copying.
+    fn resolve_vlog_value_bytes(&self, key: &[u8], prefixed: Bytes) -> Result<Option<Bytes>> {
+        if prefixed.is_empty() {
+            return Ok(None);
+        }
+        match KvKind::from_u8(prefixed[0]) {
+            Some(KvKind::ValuePointer) => {
+                let ptr = ValuePointer::try_decode(&prefixed[1..]).ok_or_else(|| {
+                    anyhow!(
+                        "invalid ValuePointer in memtable: len={}, bytes={:?}",
+                        prefixed.len(),
+                        &prefixed[..prefixed.len().min(20)]
+                    )
+                })?;
+                let vlog = self.vlog.as_ref().unwrap();
+                let bytes = vlog.read(&ptr, key)?;
+                Ok(Some(bytes))
+            }
+            _ => {
+                // Inline value — strip the kind prefix with zero-copy slice
+                if prefixed.len() == 1 {
+                    // Tombstone
+                    Ok(None)
+                } else {
+                    Ok(Some(prefixed.slice(1..)))
                 }
             }
         }
@@ -771,65 +801,62 @@ impl LsmStorageInner {
             }
         }
 
-        // L0 SSTs
-        let mut sstables_l0 = vec![];
-        state.l0_sstables.iter().for_each(|id| {
+        // L0 SSTs, from latest to earliest. Single-pass: check range + bloom
+        // and create iterator immediately, avoiding intermediate Vec allocation.
+        for id in state.l0_sstables.iter() {
             if let Some(s) = state.sstables.get(id) {
                 if key < s.first_key().raw_ref() || key > s.last_key().raw_ref() {
-                    return;
+                    continue;
                 }
-                if let Some(b) = &s.bloom {
-                    let key_hash = farmhash::hash32(key);
-                    if !b.may_contain(key_hash) {
-                        return;
-                    }
+                if let Some(b) = &s.bloom
+                    && !b.may_contain(farmhash::hash32(key))
+                {
+                    continue;
                 }
-                sstables_l0.push(s.clone());
-            }
-        });
-
-        for s in sstables_l0.iter() {
-            let mut s_it =
-                SsTableIterator::create_and_seek_to_key(s.clone(), KeySlice::from_slice(key))?;
-            if let Some(ref vlog) = self.vlog {
-                s_it.set_vlog(vlog.clone());
-            }
-            if s_it.is_valid() && s_it.key().raw_ref() == key {
-                let raw = s_it.raw_value();
-                return Ok(Self::parse_value_kind(raw));
+                let mut s_it =
+                    SsTableIterator::create_and_seek_to_key(s.clone(), KeySlice::from_slice(key))?;
+                if let Some(ref vlog) = self.vlog {
+                    s_it.set_vlog(vlog.clone());
+                }
+                if s_it.is_valid() && s_it.key().raw_ref() == key {
+                    let raw = s_it.raw_value();
+                    return Ok(Self::parse_value_kind(raw));
+                }
             }
         }
 
-        // L1-lmax SSTs
+        // L1-lmax SSTs: binary search on sorted, non-overlapping sst_ids.
+        // At most one SST per level can contain the key, so O(log N) per level.
         for (_, sst_ids) in state.levels.iter() {
-            let mut sstables = vec![];
-            sst_ids.iter().for_each(|id| {
-                if let Some(s) = state.sstables.get(id) {
-                    if key < s.first_key().raw_ref() || key > s.last_key().raw_ref() {
-                        return;
-                    }
-                    if let Some(b) = &s.bloom {
-                        let key_hash = farmhash::hash32(key);
-                        if !b.may_contain(key_hash) {
-                            return;
-                        }
-                    }
-                    sstables.push(s.clone());
-                }
+            let idx = sst_ids.partition_point(|id| {
+                state
+                    .sstables
+                    .get(id)
+                    .is_none_or(|s| s.first_key().as_key_slice() <= KeySlice::from_slice(key))
             });
 
-            let s_it = if let Some(ref vlog) = self.vlog {
-                SstConcatIterator::create_and_seek_to_key_with_vlog(
-                    sstables,
-                    KeySlice::from_slice(key),
-                    vlog.clone(),
-                )?
-            } else {
-                SstConcatIterator::create_and_seek_to_key(sstables, KeySlice::from_slice(key))?
-            };
-            if s_it.is_valid() && s_it.key().raw_ref() == key {
-                let raw = s_it.raw_value();
-                return Ok(Self::parse_value_kind(raw));
+            if idx == 0 {
+                continue;
+            }
+            let candidate_idx = idx - 1;
+            if let Some(s) = state.sstables.get(&sst_ids[candidate_idx]) {
+                if key < s.first_key().raw_ref() || key > s.last_key().raw_ref() {
+                    continue;
+                }
+                if let Some(b) = &s.bloom
+                    && !b.may_contain(farmhash::hash32(key))
+                {
+                    continue;
+                }
+                let mut s_it =
+                    SsTableIterator::create_and_seek_to_key(s.clone(), KeySlice::from_slice(key))?;
+                if let Some(ref vlog) = self.vlog {
+                    s_it.set_vlog(vlog.clone());
+                }
+                if s_it.is_valid() && s_it.key().raw_ref() == key {
+                    let raw = s_it.raw_value();
+                    return Ok(Self::parse_value_kind(raw));
+                }
             }
         }
 
@@ -901,7 +928,7 @@ impl LsmStorageInner {
     /// duplicate keys (vLog entries are unique per key).
     pub(crate) fn compare_and_set_batch_with_kind(
         &self,
-        entries: &[(Vec<u8>, Vec<u8>, KvKind, Vec<u8>, KvKind)],
+        entries: &[CasEntry],
     ) -> Result<Vec<bool>> {
         let _lock = self.state_lock.lock();
 

--- a/mini-lsm-starter/src/lsm_storage.rs
+++ b/mini-lsm-starter/src/lsm_storage.rs
@@ -611,13 +611,14 @@ impl LsmStorageInner {
 
         // L0 SSTs, from latest to earliest. Single-pass: check range + bloom
         // and create iterator immediately, avoiding intermediate Vec allocation.
+        let key_hash = farmhash::hash32(key);
         for id in state.l0_sstables.iter() {
             if let Some(s) = state.sstables.get(id) {
                 if key < s.first_key().raw_ref() || key > s.last_key().raw_ref() {
                     continue;
                 }
                 if let Some(b) = &s.bloom
-                    && !b.may_contain(farmhash::hash32(key))
+                    && !b.may_contain(key_hash)
                 {
                     continue;
                 }
@@ -655,7 +656,7 @@ impl LsmStorageInner {
                     continue;
                 }
                 if let Some(b) = &s.bloom
-                    && !b.may_contain(farmhash::hash32(key))
+                    && !b.may_contain(key_hash)
                 {
                     continue;
                 }
@@ -803,13 +804,14 @@ impl LsmStorageInner {
 
         // L0 SSTs, from latest to earliest. Single-pass: check range + bloom
         // and create iterator immediately, avoiding intermediate Vec allocation.
+        let key_hash = farmhash::hash32(key);
         for id in state.l0_sstables.iter() {
             if let Some(s) = state.sstables.get(id) {
                 if key < s.first_key().raw_ref() || key > s.last_key().raw_ref() {
                     continue;
                 }
                 if let Some(b) = &s.bloom
-                    && !b.may_contain(farmhash::hash32(key))
+                    && !b.may_contain(key_hash)
                 {
                     continue;
                 }
@@ -844,7 +846,7 @@ impl LsmStorageInner {
                     continue;
                 }
                 if let Some(b) = &s.bloom
-                    && !b.may_contain(farmhash::hash32(key))
+                    && !b.may_contain(key_hash)
                 {
                     continue;
                 }

--- a/mini-lsm-starter/src/mem_table.rs
+++ b/mini-lsm-starter/src/mem_table.rs
@@ -162,10 +162,11 @@ impl MemTable {
         }
         for entry in self.map.iter() {
             let val = entry.value();
-            if val.len() > 1 && val[0] == KvKind::ValuePointer as u8 {
-                if let Some(ptr) = ValuePointer::try_decode(&val[1..]) {
-                    ids.insert(ptr.file_id);
-                }
+            if val.len() > 1
+                && val[0] == KvKind::ValuePointer as u8
+                && let Some(ptr) = ValuePointer::try_decode(&val[1..])
+            {
+                ids.insert(ptr.file_id);
             }
         }
         ids

--- a/mini-lsm-starter/src/vlog/gc.rs
+++ b/mini-lsm-starter/src/vlog/gc.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use anyhow::{Ok, Result};
 use bytes::Bytes;
 
-use crate::lsm_storage::LsmStorageInner;
+use crate::lsm_storage::{CasEntry, LsmStorageInner};
 use crate::vlog::builder::ValueLogWriter;
 use crate::vlog::{KvKind, ValueLog, ValuePointer};
 
@@ -163,8 +163,7 @@ impl<'a> GarbageCollector<'a> {
             }
 
             // Phase 2: Batch CAS all keys under a single lock acquisition
-            let mut batch: Vec<(Vec<u8>, Vec<u8>, KvKind, Vec<u8>, KvKind)> =
-                Vec::with_capacity(rewrites.len());
+            let mut batch: Vec<CasEntry> = Vec::with_capacity(rewrites.len());
             for (key, _value, old_ptr, new_ptr) in &rewrites {
                 let mut old_buf = Vec::with_capacity(1 + ValuePointer::encoded_size());
                 old_buf.push(KvKind::ValuePointer as u8);
@@ -186,10 +185,8 @@ impl<'a> GarbageCollector<'a> {
 
             // Cache successfully rewritten entries so subsequent reads avoid disk.
             for (succeeded, (_key, value, _old_ptr, new_ptr)) in cas_results.iter().zip(&rewrites) {
-                if *succeeded {
-                    if let Some(val) = value {
-                        self.vlog.insert_cache(*new_ptr, val.clone());
-                    }
+                if *succeeded && let Some(val) = value {
+                    self.vlog.insert_cache(*new_ptr, val.clone());
                 }
             }
 

--- a/mini-lsm-starter/src/vlog/mod.rs
+++ b/mini-lsm-starter/src/vlog/mod.rs
@@ -678,11 +678,10 @@ impl ValueLog {
             if let Some(name_str) = name.to_str()
                 && let Some(stem) = name_str.strip_suffix(".vlog")
                 && stem.parse::<u32>().is_ok()
+                && let Ok(meta) = entry.metadata()
             {
-                if let Ok(meta) = entry.metadata() {
-                    vlog_file_count += 1;
-                    vlog_total_bytes += meta.len();
-                }
+                vlog_file_count += 1;
+                vlog_total_bytes += meta.len();
             }
         }
         Ok(ValueLogStats {

--- a/mini-lsm-starter/src/vlog_integration_tests.rs
+++ b/mini-lsm-starter/src/vlog_integration_tests.rs
@@ -202,7 +202,7 @@ fn test_end_to_end_mixed_inline_and_pointer() {
 
     // Write small and large values
     storage.put(b"small", b"tiny").unwrap();
-    storage.put(b"large", &vec![b'y'; 128]).unwrap();
+    storage.put(b"large", &[b'y'; 128]).unwrap();
 
     storage
         .inner
@@ -228,7 +228,7 @@ fn test_scan_with_vlog_values() {
     let storage = MiniLsm::open(dir.path(), options).unwrap();
 
     storage.put(b"a", b"aaa").unwrap(); // small
-    storage.put(b"b", &vec![b'b'; 64]).unwrap(); // large
+    storage.put(b"b", &[b'b'; 64]).unwrap(); // large
     storage.put(b"c", b"ccc").unwrap(); // small
 
     storage
@@ -261,9 +261,9 @@ fn test_compaction_with_mixed_inline_and_pointer() {
 
     // Write small (inline) and large (pointer) values
     storage.put(b"aaa", b"tiny_aaa").unwrap();
-    storage.put(b"bbb", &vec![b'b'; 128]).unwrap();
+    storage.put(b"bbb", &[b'b'; 128]).unwrap();
     storage.put(b"ccc", b"tiny_ccc").unwrap();
-    storage.put(b"ddd", &vec![b'd'; 128]).unwrap();
+    storage.put(b"ddd", &[b'd'; 128]).unwrap();
 
     // Flush to create SSTs
     storage
@@ -273,7 +273,7 @@ fn test_compaction_with_mixed_inline_and_pointer() {
     storage.inner.force_flush_next_imm_memtable().unwrap();
 
     storage.put(b"eee", b"tiny_eee").unwrap();
-    storage.put(b"fff", &vec![b'f'; 128]).unwrap();
+    storage.put(b"fff", &[b'f'; 128]).unwrap();
     storage
         .inner
         .force_freeze_memtable(&storage.inner.state_lock.lock())
@@ -318,9 +318,9 @@ fn test_recovery_with_vlog_records() {
     // Write data and flush
     {
         let storage = MiniLsm::open(dir.path(), options.clone()).unwrap();
-        storage.put(b"key1", &vec![b'a'; 64]).unwrap();
+        storage.put(b"key1", &[b'a'; 64]).unwrap();
         storage.put(b"key2", b"small").unwrap();
-        storage.put(b"key3", &vec![b'c'; 128]).unwrap();
+        storage.put(b"key3", &[b'c'; 128]).unwrap();
         storage
             .inner
             .force_freeze_memtable(&storage.inner.state_lock.lock())
@@ -384,8 +384,8 @@ fn test_multiple_flushes_different_vlog_files() {
     let storage = MiniLsm::open(dir.path(), options).unwrap();
 
     // First flush — large values go to vLog file 0
-    storage.put(b"a1", &vec![b'a'; 64]).unwrap();
-    storage.put(b"a2", &vec![b'b'; 64]).unwrap();
+    storage.put(b"a1", &[b'a'; 64]).unwrap();
+    storage.put(b"a2", &[b'b'; 64]).unwrap();
     storage
         .inner
         .force_freeze_memtable(&storage.inner.state_lock.lock())
@@ -393,8 +393,8 @@ fn test_multiple_flushes_different_vlog_files() {
     storage.inner.force_flush_next_imm_memtable().unwrap();
 
     // Second flush — large values go to vLog file 1
-    storage.put(b"b1", &vec![b'c'; 64]).unwrap();
-    storage.put(b"b2", &vec![b'd'; 64]).unwrap();
+    storage.put(b"b1", &[b'c'; 64]).unwrap();
+    storage.put(b"b2", &[b'd'; 64]).unwrap();
     storage
         .inner
         .force_freeze_memtable(&storage.inner.state_lock.lock())
@@ -402,7 +402,7 @@ fn test_multiple_flushes_different_vlog_files() {
     storage.inner.force_flush_next_imm_memtable().unwrap();
 
     // Third flush
-    storage.put(b"c1", &vec![b'e'; 64]).unwrap();
+    storage.put(b"c1", &[b'e'; 64]).unwrap();
     storage
         .inner
         .force_freeze_memtable(&storage.inner.state_lock.lock())
@@ -549,8 +549,8 @@ fn test_gc_preserves_live_values() {
     let storage = MiniLsm::open(dir.path(), options).unwrap();
 
     // Write large values
-    storage.put(b"keep", &vec![b'k'; 64]).unwrap();
-    storage.put(b"overwrite", &vec![b'o'; 64]).unwrap();
+    storage.put(b"keep", &[b'k'; 64]).unwrap();
+    storage.put(b"overwrite", &[b'o'; 64]).unwrap();
 
     storage
         .inner
@@ -559,7 +559,7 @@ fn test_gc_preserves_live_values() {
     storage.inner.force_flush_next_imm_memtable().unwrap();
 
     // Overwrite "overwrite" with a new value
-    storage.put(b"overwrite", &vec![b'n'; 64]).unwrap();
+    storage.put(b"overwrite", &[b'n'; 64]).unwrap();
 
     storage
         .inner
@@ -592,8 +592,8 @@ fn test_gc_below_threshold() {
     }
     let storage = MiniLsm::open(dir.path(), options).unwrap();
 
-    storage.put(b"key1", &vec![b'a'; 64]).unwrap();
-    storage.put(b"key2", &vec![b'b'; 64]).unwrap();
+    storage.put(b"key1", &[b'a'; 64]).unwrap();
+    storage.put(b"key2", &[b'b'; 64]).unwrap();
 
     storage
         .inner
@@ -602,7 +602,7 @@ fn test_gc_below_threshold() {
     storage.inner.force_flush_next_imm_memtable().unwrap();
 
     // Overwrite key1
-    storage.put(b"key1", &vec![b'c'; 64]).unwrap();
+    storage.put(b"key1", &[b'c'; 64]).unwrap();
     storage
         .inner
         .force_freeze_memtable(&storage.inner.state_lock.lock())
@@ -632,8 +632,8 @@ fn test_trigger_gc_api() {
     }
     let storage = MiniLsm::open(dir.path(), options).unwrap();
 
-    storage.put(b"key1", &vec![b'a'; 64]).unwrap();
-    storage.put(b"key2", &vec![b'b'; 64]).unwrap();
+    storage.put(b"key1", &[b'a'; 64]).unwrap();
+    storage.put(b"key2", &[b'b'; 64]).unwrap();
 
     storage
         .inner
@@ -664,8 +664,8 @@ fn test_gc_multiple_files() {
     let storage = MiniLsm::open(dir.path(), options).unwrap();
 
     // First flush — large values go to vLog file 0
-    storage.put(b"a1", &vec![b'a'; 64]).unwrap();
-    storage.put(b"a2", &vec![b'b'; 64]).unwrap();
+    storage.put(b"a1", &[b'a'; 64]).unwrap();
+    storage.put(b"a2", &[b'b'; 64]).unwrap();
     storage
         .inner
         .force_freeze_memtable(&storage.inner.state_lock.lock())
@@ -673,8 +673,8 @@ fn test_gc_multiple_files() {
     storage.inner.force_flush_next_imm_memtable().unwrap();
 
     // Second flush — large values go to vLog file 1
-    storage.put(b"b1", &vec![b'c'; 64]).unwrap();
-    storage.put(b"b2", &vec![b'd'; 64]).unwrap();
+    storage.put(b"b1", &[b'c'; 64]).unwrap();
+    storage.put(b"b2", &[b'd'; 64]).unwrap();
     storage
         .inner
         .force_freeze_memtable(&storage.inner.state_lock.lock())
@@ -682,10 +682,10 @@ fn test_gc_multiple_files() {
     storage.inner.force_flush_next_imm_memtable().unwrap();
 
     // Overwrite all keys
-    storage.put(b"a1", &vec![b'x'; 64]).unwrap();
-    storage.put(b"a2", &vec![b'x'; 64]).unwrap();
-    storage.put(b"b1", &vec![b'x'; 64]).unwrap();
-    storage.put(b"b2", &vec![b'x'; 64]).unwrap();
+    storage.put(b"a1", &[b'x'; 64]).unwrap();
+    storage.put(b"a2", &[b'x'; 64]).unwrap();
+    storage.put(b"b1", &[b'x'; 64]).unwrap();
+    storage.put(b"b2", &[b'x'; 64]).unwrap();
     storage
         .inner
         .force_freeze_memtable(&storage.inner.state_lock.lock())
@@ -714,8 +714,8 @@ fn test_gc_analyze_file() {
     let options = options_with_vlog_enabled(256, 1 << 20);
     let storage = MiniLsm::open(dir.path(), options).unwrap();
 
-    storage.put(b"key1", &vec![b'a'; 64]).unwrap();
-    storage.put(b"key2", &vec![b'b'; 64]).unwrap();
+    storage.put(b"key1", &[b'a'; 64]).unwrap();
+    storage.put(b"key2", &[b'b'; 64]).unwrap();
 
     storage
         .inner
@@ -817,8 +817,8 @@ fn test_crash_recovery_after_partial_flush() {
     // Write data with WAL enabled
     {
         let storage = MiniLsm::open(dir.path(), options.clone()).unwrap();
-        storage.put(b"key1", &vec![b'a'; 128]).unwrap();
-        storage.put(b"key2", &vec![b'b'; 128]).unwrap();
+        storage.put(b"key1", &[b'a'; 128]).unwrap();
+        storage.put(b"key2", &[b'b'; 128]).unwrap();
         storage.put(b"key3", b"small").unwrap(); // inline
 
         // Force flush to create SST + vLog entries
@@ -829,7 +829,7 @@ fn test_crash_recovery_after_partial_flush() {
         storage.inner.force_flush_next_imm_memtable().unwrap();
 
         // Write more data after flush (only in WAL + memtable)
-        storage.put(b"key4", &vec![b'd'; 128]).unwrap();
+        storage.put(b"key4", &[b'd'; 128]).unwrap();
         storage.put(b"key5", b"small_after").unwrap();
 
         // Simulate crash by dropping without clean close
@@ -876,7 +876,7 @@ fn test_orphan_vlog_cleanup_on_startup() {
     // Write data and flush to create real vLog files
     {
         let storage = MiniLsm::open(dir.path(), options.clone()).unwrap();
-        storage.put(b"key1", &vec![b'a'; 64]).unwrap();
+        storage.put(b"key1", &[b'a'; 64]).unwrap();
         storage
             .inner
             .force_freeze_memtable(&storage.inner.state_lock.lock())
@@ -908,7 +908,7 @@ fn test_orphan_vlog_cleanup_on_startup() {
         );
 
         // Engine should work normally — new writes should succeed
-        storage.put(b"key2", &vec![b'b'; 64]).unwrap();
+        storage.put(b"key2", &[b'b'; 64]).unwrap();
         assert_eq!(
             storage.get(b"key2").unwrap(),
             Some(Bytes::from(vec![b'b'; 64]))
@@ -925,9 +925,9 @@ fn test_range_scan_deduplication() {
     let storage = MiniLsm::open(dir.path(), options).unwrap();
 
     // Write large values
-    storage.put(b"aaa", &vec![b'x'; 64]).unwrap();
-    storage.put(b"bbb", &vec![b'y'; 64]).unwrap();
-    storage.put(b"ccc", &vec![b'z'; 64]).unwrap();
+    storage.put(b"aaa", &[b'x'; 64]).unwrap();
+    storage.put(b"bbb", &[b'y'; 64]).unwrap();
+    storage.put(b"ccc", &[b'z'; 64]).unwrap();
 
     // First flush — values go to vLog
     storage
@@ -937,7 +937,7 @@ fn test_range_scan_deduplication() {
     storage.inner.force_flush_next_imm_memtable().unwrap();
 
     // Overwrite "bbb" with a new value
-    storage.put(b"bbb", &vec![b'w'; 64]).unwrap();
+    storage.put(b"bbb", &[b'w'; 64]).unwrap();
 
     // Second flush
     storage
@@ -984,8 +984,8 @@ fn test_mixed_inline_pointer_after_enable() {
     storage.put(b"inline2", b"tiny_b").unwrap();
 
     // Write large values (above min_value_size → vLog pointer)
-    storage.put(b"vlog1", &vec![b'x'; 64]).unwrap();
-    storage.put(b"vlog2", &vec![b'y'; 64]).unwrap();
+    storage.put(b"vlog1", &[b'x'; 64]).unwrap();
+    storage.put(b"vlog2", &[b'y'; 64]).unwrap();
 
     // Flush first batch
     storage
@@ -996,7 +996,7 @@ fn test_mixed_inline_pointer_after_enable() {
 
     // Write more mixed values
     storage.put(b"inline3", b"tiny_c").unwrap();
-    storage.put(b"vlog3", &vec![b'z'; 64]).unwrap();
+    storage.put(b"vlog3", &[b'z'; 64]).unwrap();
 
     // Flush second batch
     storage
@@ -1085,7 +1085,7 @@ fn test_gc_batch_cas() {
     // Overwrite half the keys
     for i in 0..5 {
         let key = format!("key_{:04}", i);
-        storage.put(key.as_bytes(), &vec![b'z'; 64]).unwrap();
+        storage.put(key.as_bytes(), &[b'z'; 64]).unwrap();
     }
     storage
         .inner
@@ -1132,8 +1132,8 @@ fn test_vlog_stats_api() {
     assert_eq!(stats.gc_files_processed, 0);
 
     // Write and flush to create vLog files
-    storage.put(b"key1", &vec![b'a'; 64]).unwrap();
-    storage.put(b"key2", &vec![b'b'; 64]).unwrap();
+    storage.put(b"key1", &[b'a'; 64]).unwrap();
+    storage.put(b"key2", &[b'b'; 64]).unwrap();
     storage
         .inner
         .force_freeze_memtable(&storage.inner.state_lock.lock())
@@ -1151,8 +1151,8 @@ fn test_vlog_stats_api() {
     );
 
     // Overwrite keys to create stale entries, flush, then compact
-    storage.put(b"key1", &vec![b'c'; 64]).unwrap();
-    storage.put(b"key2", &vec![b'd'; 64]).unwrap();
+    storage.put(b"key1", &[b'c'; 64]).unwrap();
+    storage.put(b"key2", &[b'd'; 64]).unwrap();
     storage
         .inner
         .force_freeze_memtable(&storage.inner.state_lock.lock())
@@ -1203,8 +1203,8 @@ fn test_value_cache_hit_miss() {
     let storage = MiniLsm::open(dir.path(), options).unwrap();
 
     // Write and flush to create vLog entries
-    storage.put(b"key1", &vec![b'a'; 64]).unwrap();
-    storage.put(b"key2", &vec![b'b'; 64]).unwrap();
+    storage.put(b"key1", &[b'a'; 64]).unwrap();
+    storage.put(b"key2", &[b'b'; 64]).unwrap();
     storage
         .inner
         .force_freeze_memtable(&storage.inner.state_lock.lock())
@@ -1266,7 +1266,7 @@ fn test_value_cache_disabled_by_default() {
     };
     let storage = MiniLsm::open(dir.path(), options).unwrap();
 
-    storage.put(b"key1", &vec![b'a'; 64]).unwrap();
+    storage.put(b"key1", &[b'a'; 64]).unwrap();
     storage
         .inner
         .force_freeze_memtable(&storage.inner.state_lock.lock())


### PR DESCRIPTION
## Summary

Optimizations to the `get()` and `get_with_kind_inner()` hot paths in `mini-lsm-starter/src/lsm_storage.rs`:

### 1. L1+ Binary-Search Point Get (biggest win)
Replaced O(N) linear scan over `sst_ids` + `SstConcatIterator` construction with O(log N) `partition_point` on sorted, non-overlapping sst_ids. At most one SST per level can contain the key — no need to scan them all.

### 2. L0 Single-Pass Direct Iteration
Eliminated intermediate `Vec<Arc<SsTable>>` allocation for L0 SSTs. Range + bloom checks and iterator creation now happen in a single pass.

### 3. Zero-Copy Inline Memtable Values (vLog path)
Added `resolve_vlog_value_bytes()` that takes `Bytes` and returns `prefixed.slice(1..)` (cheap refcount bump) instead of `Bytes::copy_from_slice` (heap alloc + memcpy) for inline values from the memtable.

### 4. Precomputed Bloom Filter Hash
`farmhash::hash32(key)` is now computed once before the L0/L1+ loops instead of redundantly for every SST bloom check.

### 5. Raw Key Comparison for MVCC Safety
`partition_point` uses `s.first_key().raw_ref() <= key` instead of `KeySlice` comparison to avoid timestamp mismatch issues when MVCC is enabled.

### 6. Direct Indexing for Fail-Fast
`state.sstables[id]` in `partition_point` panics loudly on invariant violations instead of silently returning wrong results.

## Final Benchmark Results (`read_point_get`)

| Benchmark | Before | After | Improvement |
|-----------|--------|-------|-------------|
| `inline` | ~1.49 µs | ~1.40 µs | **-6%** |
| `vlog` | ~4.07 µs | ~3.89 µs | **-4.4%** |
| `vlog_cached` | ~2.21 µs | ~2.15 µs | **-2.7%** |

## Safety
- No public API changes
- Scan path untouched
- All clippy warnings fixed across lib, tests, and benchmarks
- 96/96 tests pass
